### PR TITLE
Upgrades Next.js to beta 33, which removes Glamor

### DIFF
--- a/components/layouts/ReportLayout.js
+++ b/components/layouts/ReportLayout.js
@@ -1,0 +1,92 @@
+// @flow
+/* eslint react/no-unused-prop-types: 0 */
+
+import React from 'react';
+
+import Nav from '../common/Nav';
+import LocationMap from '../location';
+import StartFormContainer from '../report-start';
+import ReportFormContainer from '../report-form';
+
+import type { LoopbackGraphql } from '../../data/graphql/loopback-graphql';
+import type { Service, ServiceSummary } from '../../data/types';
+
+type ServiceProps = {
+  view: 'service',
+  code: string,
+  service: ?Service,
+  pickLocation: boolean,
+};
+
+type SummaryProps = {
+  view: 'summaries',
+  serviceSummaries: ?ServiceSummary[],
+  pickLocation: boolean,
+};
+
+export type InitialProps = ServiceProps | SummaryProps;
+
+export type Props = {
+  initialProps: InitialProps,
+  loopbackGraphql: LoopbackGraphql,
+  showServiceForm: (ServiceSummary) => void,
+  goToReportForm: () => void,
+}
+
+export default class ReportLayout extends React.Component {
+  props: Props;
+
+  static getTitle(initialProps: InitialProps) {
+    switch (initialProps.view) {
+      case 'summaries': return 'Report a Problem';
+      case 'service': {
+        const { service, pickLocation } = initialProps;
+
+        if (pickLocation) {
+          return 'Choose location';
+        } else if (service) {
+          return service.name;
+        } else {
+          return 'Not found';
+        }
+      }
+      default: return '';
+    }
+  }
+
+  render() {
+    const { initialProps: { pickLocation }, goToReportForm } = this.props;
+
+    return (
+      <div>
+        <Nav />
+        <LocationMap active={pickLocation} goToReportForm={goToReportForm} />
+
+        {this.renderContent()}
+      </div>
+    );
+  }
+
+  renderContent() {
+    const { initialProps, showServiceForm, loopbackGraphql } = this.props;
+
+    switch (initialProps.view) {
+      case 'summaries':
+        return (
+          <StartFormContainer serviceSummaries={initialProps.serviceSummaries} showServiceForm={showServiceForm} />
+        );
+
+      case 'service': {
+        const { service, pickLocation } = initialProps;
+        if (pickLocation) {
+          return null;
+        } else {
+          return <ReportFormContainer service={service} loopbackGraphql={loopbackGraphql} />;
+        }
+      }
+
+      default:
+        return null;
+    }
+  }
+}

--- a/components/layouts/ReportLayout.test.js
+++ b/components/layouts/ReportLayout.test.js
@@ -1,0 +1,163 @@
+// @flow
+/* eslint no-fallthrough: 0 */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Provider } from 'react-redux';
+import ReportLayout from './ReportLayout';
+import type { Service, ServiceSummary } from '../../data/types';
+import { makeStore } from '../../data/store';
+
+const MOCK_SERVICE_SUMMARIES: ServiceSummary[] = [{
+  name: 'Cosmic Incursion',
+  code: 'CSMCINC',
+  hasMetadata: true,
+  locationRequired: true,
+}];
+
+const MOCK_SERVICE: Service = {
+  name: 'Cosmic Incursion',
+  code: 'CSMCINC',
+  hasMetadata: true,
+  metadata: {
+    attributes: [{
+      required: false,
+      type: 'TEXT',
+      code: 'ST-CMTS',
+      description: 'Please provide any other relevant information:',
+      values: null,
+    }, {
+      required: false,
+      type: 'STRING',
+      code: 'INFO-CSIRMV1',
+      description: '**All cosmic incursion cases should be followed up with a phone call to Alpha Flight.**',
+      values: null,
+    }, {
+      required: true,
+      type: 'SINGLEVALUELIST',
+      code: 'SR-CSIRMV1',
+      description: 'How many dimensions have been breached?',
+      values: [{ key: 'One', name: 'One' }, { key: 'Two', name: 'Two' }, { key: 'Three', name: 'Three' }, { key: 'More than Three', name: 'More than Three' }],
+    }],
+  },
+};
+
+let store;
+let defaultProps;
+
+beforeEach(() => {
+  store = makeStore();
+
+  defaultProps = {
+    showServiceForm: jest.fn(),
+    loopbackGraphql: jest.fn(),
+    goToReportForm: jest.fn(),
+  };
+});
+
+describe('report form', () => {
+  let initialProps;
+  beforeEach(() => {
+    initialProps = {
+      view: 'summaries',
+      serviceSummaries: MOCK_SERVICE_SUMMARIES,
+      pickLocation: false,
+    };
+  });
+
+  test('title', () => {
+    expect(ReportLayout.getTitle(initialProps)).toEqual('Report a Problem');
+  });
+
+  test('rendering', () => {
+    const component = renderer.create(
+      <Provider store={store}>
+        <ReportLayout initialProps={initialProps} {...defaultProps} />
+      </Provider>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});
+
+describe('service form', () => {
+  describe('existing', () => {
+    let initialProps;
+
+    beforeEach(() => {
+      initialProps = {
+        view: 'service',
+        code: 'CSMCINC',
+        service: MOCK_SERVICE,
+        pickLocation: false,
+      };
+    });
+
+    test('title', () => {
+      expect(ReportLayout.getTitle(initialProps)).toEqual('Cosmic Incursion');
+    });
+
+    test('rendering', () => {
+      const component = renderer.create(
+        <Provider store={store}>
+          <ReportLayout initialProps={initialProps} {...defaultProps} />
+        </Provider>,
+      );
+
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe('missing', () => {
+    let initialProps;
+
+    beforeEach(() => {
+      initialProps = {
+        view: 'service',
+        code: 'INFEARTHS',
+        service: null,
+        pickLocation: false,
+      };
+    });
+
+    test('title', () => {
+      expect(ReportLayout.getTitle(initialProps)).toEqual('Not found');
+    });
+
+    test('rendering missing', () => {
+      const component = renderer.create(
+        <Provider store={store}>
+          <ReportLayout initialProps={initialProps} {...defaultProps} />
+        </Provider>,
+    );
+
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+});
+
+describe('location picker', () => {
+  let initialProps;
+
+  beforeEach(() => {
+    initialProps = {
+      view: 'service',
+      code: 'CSMCINC',
+      service: MOCK_SERVICE,
+      pickLocation: true,
+    };
+  });
+
+  test('title', () => {
+    expect(ReportLayout.getTitle(initialProps)).toEqual('Choose location');
+  });
+
+  test('rendering', () => {
+    const component = renderer.create(
+      <Provider store={store}>
+        <ReportLayout initialProps={initialProps} {...defaultProps} />
+      </Provider>,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/components/layouts/__snapshots__/ReportLayout.test.js.snap
+++ b/components/layouts/__snapshots__/ReportLayout.test.js.snap
@@ -1,0 +1,366 @@
+exports[`location picker rendering 1`] = `
+<div>
+  <div
+    className="nav ft-ll css-1avoji2">
+    <a
+      href="/"
+      onClick={[Function]}>
+      Report a problem
+    </a>
+    <a
+      href="/lookup"
+      onClick={[Function]}>
+      Case look up
+    </a>
+    <a
+      href="/go"
+      onClick={[Function]}>
+      311 on the go
+    </a>
+    <a
+      href="/faq"
+      onClick={[Function]}>
+      FAQ
+    </a>
+  </div>
+</div>
+`;
+
+exports[`report form rendering 1`] = `
+<div>
+  <div
+    className="nav ft-ll css-1avoji2">
+    <a
+      href="/"
+      onClick={[Function]}>
+      Report a problem
+    </a>
+    <a
+      href="/lookup"
+      onClick={[Function]}>
+      Case look up
+    </a>
+    <a
+      href="/go"
+      onClick={[Function]}>
+      311 on the go
+    </a>
+    <a
+      href="/faq"
+      onClick={[Function]}>
+      FAQ
+    </a>
+  </div>
+  <div
+    className={
+      Object {
+        "data-css-1t5zf7p": "",
+      }
+    }>
+    <div
+      className="sh sh--y"
+      style={
+        Object {
+          "marginBottom": 40,
+        }
+      }>
+      <h2
+        className="sh-title">
+        311: Boston City Services
+      </h2>
+    </div>
+    <div
+      className={
+        Object {
+          "data-css-9sglvw": "",
+        }
+      }>
+      <textarea
+        className={
+          Object {
+            "data-css-1j8x7ul": "",
+          }
+        }
+        defaultValue=""
+        name="description"
+        onInput={[Function]}
+        placeholder="How can we help?" />
+      <ul
+        className={
+          Object {
+            "data-css-117fchh": "",
+          }
+        }>
+        <li
+          className={
+            Object {
+              "data-css-14nloni": "",
+            }
+          }>
+          <a
+            className={
+              Object {
+                "data-css-3br7c8": "",
+              }
+            }
+            href="/report/CSMCINC/location"
+            onClick={[Function]}>
+            Cosmic Incursion
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`service form existing rendering 1`] = `
+<div>
+  <div
+    className="nav ft-ll css-1avoji2">
+    <a
+      href="/"
+      onClick={[Function]}>
+      Report a problem
+    </a>
+    <a
+      href="/lookup"
+      onClick={[Function]}>
+      Case look up
+    </a>
+    <a
+      href="/go"
+      onClick={[Function]}>
+      311 on the go
+    </a>
+    <a
+      href="/faq"
+      onClick={[Function]}>
+      FAQ
+    </a>
+  </div>
+  <div
+    className={
+      Object {
+        "data-css-1t5zf7p": "",
+      }
+    }>
+    <div
+      className="sh sh--y"
+      style={
+        Object {
+          "marginBottom": 40,
+        }
+      }>
+      <h2
+        className="sh-title">
+        Cosmic Incursion
+      </h2>
+    </div>
+    <div
+      className={
+        Object {
+          "data-css-dgukzt": "",
+        }
+      }>
+      
+    </div>
+    <div>
+      <label>
+        <p>
+          Please provide any other relevant information:
+           
+        </p>
+        <textarea
+          className={
+            Object {
+              "data-css-1bm19ha": "",
+            }
+          }
+          name="ST-CMTS"
+          onInput={[Function]} />
+      </label>
+      <p>
+        **All cosmic incursion cases should be followed up with a phone call to Alpha Flight.**
+      </p>
+      <label>
+        <p>
+          How many dimensions have been breached?
+        </p>
+        <select
+          name="SR-CSIRMV1"
+          onInput={[Function]}>
+          <option
+            value="One">
+            One
+          </option>
+          <option
+            value="Two">
+            Two
+          </option>
+          <option
+            value="Three">
+            Three
+          </option>
+          <option
+            value="More than Three">
+            More than Three
+          </option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <h2
+        className={
+          Object {
+            "data-css-16pm9zd": "",
+          }
+        }>
+        CONTACT FORM
+      </h2>
+      <div
+        className={
+          Object {
+            "data-css-1w0rge6": "",
+          }
+        }>
+        (will not be shared with public; leave blank to submit anonymously)
+      </div>
+      <label
+        className={
+          Object {
+            "data-css-12a7iqv": "",
+          }
+        }>
+        <span>
+          First Name (required)
+        </span>
+        <input
+          className={
+            Object {
+              "data-css-b35x0h": "",
+            }
+          }
+          name="firstName"
+          onChange={[Function]}
+          placeholder="First Name"
+          value="" />
+      </label>
+      <label
+        className={
+          Object {
+            "data-css-12a7iqv": "",
+          }
+        }>
+        <span>
+          Last Name (required)
+        </span>
+        <input
+          className={
+            Object {
+              "data-css-b35x0h": "",
+            }
+          }
+          name="lastName"
+          onChange={[Function]}
+          placeholder="Last Name"
+          value="" />
+      </label>
+      <label
+        className={
+          Object {
+            "data-css-12a7iqv": "",
+          }
+        }>
+        <span>
+          Email (required)
+        </span>
+        <input
+          className={
+            Object {
+              "data-css-b35x0h": "",
+            }
+          }
+          name="email"
+          onChange={[Function]}
+          placeholder="Email"
+          type="email"
+          value="" />
+      </label>
+      <label
+        className={
+          Object {
+            "data-css-12a7iqv": "",
+          }
+        }>
+        <span>
+          Phone
+        </span>
+        <input
+          className={
+            Object {
+              "data-css-b35x0h": "",
+            }
+          }
+          name="phone"
+          onChange={[Function]}
+          placeholder="Phone"
+          type="tel"
+          value="" />
+      </label>
+    </div>
+    <button
+      disabled={true}
+      onClick={[Function]}>
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`service form missing rendering missing 1`] = `
+<div>
+  <div
+    className="nav ft-ll css-1avoji2">
+    <a
+      href="/"
+      onClick={[Function]}>
+      Report a problem
+    </a>
+    <a
+      href="/lookup"
+      onClick={[Function]}>
+      Case look up
+    </a>
+    <a
+      href="/go"
+      onClick={[Function]}>
+      311 on the go
+    </a>
+    <a
+      href="/faq"
+      onClick={[Function]}>
+      FAQ
+    </a>
+  </div>
+  <div
+    className={
+      Object {
+        "data-css-1t5zf7p": "",
+      }
+    }>
+    <div
+      className="sh sh--y"
+      style={
+        Object {
+          "marginBottom": 40,
+        }
+      }>
+      <h2
+        className="sh-title">
+        Service not found
+      </h2>
+    </div>
+  </div>
+</div>
+`;

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -28,7 +28,7 @@ let browserStore = null;
 
 // Factored out to allow for injecting test dependencies and state while
 // maintaining the same middleware.
-export function makeStore(initialState: ?State = null): Store {
+export function makeStore(initialState: ?State = undefined): Store {
   const reducer: Reducer<State, Action> = combineReducers({
     keys,
     request,
@@ -59,7 +59,7 @@ export function makeStore(initialState: ?State = null): Store {
  * server’s getInitialProps calls. Can be null when server rendering or on the
  * client.
  */
-export default function getStore(req: ?RequestAdditions, initialState: ?State = null): Store {
+export default function getStore(req: ?RequestAdditions, initialState: ?State = undefined): Store {
   if (process.browser && browserStore) {
     return browserStore;
   }

--- a/data/types.js
+++ b/data/types.js
@@ -6,12 +6,33 @@ import type {
 //  LoadServiceQuery,
   LoadServiceQueryVariables,
   LoadServiceSummariesQuery,
-  LoadServiceQuery,
+  ServiceMetadataAttributeDatatype,
   SubmitRequestMutation,
 } from './graphql/schema.flow';
 
 export type ServiceSummary = $ArrayElement<$PropertyType<LoadServiceSummariesQuery, 'services'>>;
-export type Service = $NonMaybeType<$PropertyType<LoadServiceQuery, 'service'>>;
+
+// HACK(finh): As of v0.40.0, Flow throws internal errors due to this use of
+// $NonMaybeType, so we manually create the Service type. :(
+// export type Service = $NonMaybeType<$PropertyType<LoadServiceQuery, 'service'>>;
+export type Service = {
+  name: string,
+  code: string,
+  hasMetadata: boolean,
+  metadata: ? {
+    attributes: Array<{
+      required: boolean,
+      type: ServiceMetadataAttributeDatatype,
+      code: string,
+      description: string,
+      values: ?Array<{
+        key: string,
+        name: string,
+      }>,
+    }>,
+  },
+};
+
 export type ServiceArgs = LoadServiceQueryVariables;
 export type ServiceMetadata = $NonMaybeType<$PropertyType<Service, 'metadata'>>;
 export type ServiceMetadataAttribute = $ArrayElement<$PropertyType<ServiceMetadata, 'attributes'>>;

--- a/flow-typed/npm/glamor_vx.x.x.js
+++ b/flow-typed/npm/glamor_vx.x.x.js
@@ -13,10 +13,21 @@
  * https://github.com/flowtype/flow-typed
  */
 
-declare module 'glamor' {
+ declare module 'glamor' {
+   declare module.exports: {
+     css: (Object) => {
+       toString: () => string;
+     },
+     rehydrate: (string[]) => void,
+   };
+ }
+
+declare module 'glamor/server' {
   declare module.exports: {
-    css: (Object) => {
-      toString: () => string;
-    },
+    renderStatic: (() => string) => {
+      html: string,
+      css: string,
+      ids: string[],
+    };
   };
 }

--- a/lib/mixins/with-store.js
+++ b/lib/mixins/with-store.js
@@ -2,10 +2,8 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
+import type { Store } from 'redux';
 import type { Context } from 'next';
-import type { RequestAdditions } from '../../server/next-handlers';
-import getStore from '../../data/store';
-import type { Store } from '../../data/store';
 
 /**
  * Higher-order React component that initializes our Redux store and preserves its
@@ -27,14 +25,16 @@ import type { Store } from '../../data/store';
  *  - When new pages are accessed on the client, their getInitialProps and constructors
  *    will received the memoized store, preserving the data throughout the session.
  */
-export default (Component: Class<React.Component<*, *, *>>) => (
-  class withStore extends React.Component {
-    store: Store;
+export type GetStore<R, S, A> = (req: ?R, initialState: ?S) => Store<S, A>;
 
-    static async getInitialProps(ctx: Context<RequestAdditions>) {
+export default <R, S, A> (getStore: GetStore<R, S, A>) => (Component: Class<React.Component<*, *, *>>) => (
+  class withStore extends React.Component {
+    store: Store<S, A>;
+
+    static async getInitialProps(ctx: Context<R>) {
       const { req } = ctx;
 
-      const initialState = req ? req.reduxInitialState : null;
+      const initialState = req ? req.reduxInitialState : undefined;
       const store = getStore(req, initialState);
 
       const props = await (typeof Component.getInitialProps === 'function' ? Component.getInitialProps(ctx, store) : {});

--- a/lib/mixins/with-store.test.js
+++ b/lib/mixins/with-store.test.js
@@ -1,0 +1,101 @@
+// @flow
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { createStore } from 'redux';
+import { connect } from 'react-redux';
+
+import withStore from './with-store';
+
+const INITIAL_STATE = {
+  step: 'first',
+};
+
+function reducer(state = INITIAL_STATE) {
+  return state;
+}
+
+function getStore(req, initialState) {
+  return createStore(reducer, initialState);
+}
+
+class TestPage extends React.Component {
+  static getInitialProps(ctx, store) {
+    return Promise.resolve({
+      initialStep: store.getState().step,
+    });
+  }
+
+  render() { return <span>{ this.props.renderStep }</span>; }
+}
+
+const TestPageContainer = connect((state) => ({
+  renderStep: state.step,
+}))(TestPage);
+
+let ctx;
+let Wrapped;
+beforeEach(() => {
+  ctx = {
+    req: ({}: any),
+    res: (({ statusCode: 200 }): any),
+    pathname: '/page',
+    query: {},
+  };
+
+  Wrapped = withStore(getStore)(TestPageContainer);
+});
+
+describe('getInitialProps on server', () => {
+  it('creates a store and calls through to the wrapped component, also returns initial state', async () => {
+    const initialProps = await Wrapped.getInitialProps(ctx);
+    expect(initialProps).toEqual({
+      initialStep: 'first',
+      initialState: INITIAL_STATE,
+    });
+  });
+
+  it('pulls the initialState off of the request', async () => {
+    const SERVER_STATE = {
+      step: 'second',
+    };
+
+    ctx.req.reduxInitialState = SERVER_STATE;
+
+    const initialProps = await Wrapped.getInitialProps(ctx);
+    expect(initialProps).toEqual({
+      initialStep: 'second',
+      initialState: SERVER_STATE,
+    });
+  });
+});
+
+describe('getInitialProps on client', () => {
+  beforeEach(() => {
+    ctx.req = null;
+    ctx.res = null;
+  });
+
+  it('creates a store and calls through to the wrapped component, also returns initial state', async () => {
+    const initialProps = await Wrapped.getInitialProps(ctx);
+    expect(initialProps).toEqual({
+      initialStep: 'first',
+      initialState: INITIAL_STATE,
+    });
+  });
+});
+
+
+describe('render', () => {
+  it('renders the wrapped component in a Provider', async () => {
+    const SERVER_STATE = {
+      step: 'second',
+    };
+
+    ctx.req.reduxInitialState = SERVER_STATE;
+    const initialProps = await Wrapped.getInitialProps(ctx);
+    const component = renderer.create(<Wrapped {...initialProps} />);
+    expect(component.toJSON()).toEqual({ children: ['second'], props: {}, type: 'span' });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "https-proxy-agent": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",
     "moment": "^2.17.1",
-    "next": "2.0.0-beta.31",
+    "next": "beta",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
@@ -84,6 +84,7 @@
     "husky": "^0.13.1",
     "jest": "^18.1.0",
     "prompt": "^1.0.0",
+    "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.4.2",
     "webpack-bundle-analyzer": "^2.3.0"
   }

--- a/pages/__snapshots__/report.test.js.snap
+++ b/pages/__snapshots__/report.test.js.snap
@@ -1,291 +1,107 @@
-exports[`test request flow 1`] = `
+exports[`location picker rendering 1`] = `
 <div>
-  <div
-    className="nav ft-ll css-1avoji2">
-    <a
-      href="/"
-      onClick={[Function]}>
-      Report a problem
-    </a>
-    <a
-      href="/lookup"
-      onClick={[Function]}>
-      Case look up
-    </a>
-    <a
-      href="/go"
-      onClick={[Function]}>
-      311 on the go
-    </a>
-    <a
-      href="/faq"
-      onClick={[Function]}>
-      FAQ
-    </a>
-  </div>
-  <div
-    className={
+  <SideEffect(Head)>
+    <title>
+      BOS:311 — 
+      Choose location
+    </title>
+  </SideEffect(Head)>
+  <ReportLayout
+    goToReportForm={[Function]}
+    initialProps={
       Object {
-        "data-css-1t5zf7p": "",
+        "code": "CSMCINC",
+        "pickLocation": true,
+        "service": Object {
+          "code": "CSMCINC",
+          "hasMetadata": false,
+          "metadata": null,
+          "name": "Cosmic Incursion",
+        },
+        "view": "service",
       }
-    }>
-    <div
-      className="sh sh--y"
-      style={
-        Object {
-          "marginBottom": 40,
-        }
-      }>
-      <h2
-        className="sh-title">
-        311: Boston City Services
-      </h2>
-    </div>
-    <div
-      className={
-        Object {
-          "data-css-9sglvw": "",
-        }
-      }>
-      <textarea
-        className={
-          Object {
-            "data-css-1j8x7ul": "",
-          }
-        }
-        defaultValue=""
-        name="description"
-        onInput={[Function]}
-        placeholder="How can we help?" />
-      <ul
-        className={
-          Object {
-            "data-css-117fchh": "",
-          }
-        }>
-        <li
-          className={
-            Object {
-              "data-css-14nloni": "",
-            }
-          }>
-          <a
-            className={
-              Object {
-                "data-css-3br7c8": "",
-              }
-            }
-            href="/report/needles/location"
-            onClick={[Function]}>
-            Needle Pickup
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
+    }
+    loopbackGraphql={[Function]}
+    showServiceForm={[Function]} />
 </div>
 `;
 
-exports[`test service page 1`] = `
+exports[`report form rendering 1`] = `
 <div>
-  <div
-    className="nav ft-ll css-1avoji2">
-    <a
-      href="/"
-      onClick={[Function]}>
-      Report a problem
-    </a>
-    <a
-      href="/lookup"
-      onClick={[Function]}>
-      Case look up
-    </a>
-    <a
-      href="/go"
-      onClick={[Function]}>
-      311 on the go
-    </a>
-    <a
-      href="/faq"
-      onClick={[Function]}>
-      FAQ
-    </a>
-  </div>
-  <div
-    className={
+  <SideEffect(Head)>
+    <title>
+      BOS:311 — 
+      Report a Problem
+    </title>
+  </SideEffect(Head)>
+  <ReportLayout
+    goToReportForm={[Function]}
+    initialProps={
       Object {
-        "data-css-1t5zf7p": "",
+        "pickLocation": false,
+        "serviceSummaries": Array [
+          Object {
+            "code": "CSMCINC",
+            "hasMetadata": true,
+            "locationRequired": true,
+            "name": "Cosmic Incursion",
+          },
+        ],
+        "view": "summaries",
       }
-    }>
-    <div
-      className="sh sh--y"
-      style={
-        Object {
-          "marginBottom": 40,
-        }
-      }>
-      <h2
-        className="sh-title">
-        Needle Pickup
-      </h2>
-    </div>
-    <div
-      className={
-        Object {
-          "data-css-dgukzt": "",
-        }
-      }>
-      
-    </div>
-    <div>
-      <label>
-        <p>
-          Please provide any other relevant information:
-           
-        </p>
-        <textarea
-          className={
-            Object {
-              "data-css-1bm19ha": "",
-            }
-          }
-          name="ST-CMTS"
-          onInput={[Function]} />
-      </label>
-      <p>
-        **All needle pickup cases should be followed up with a phone call to one of the below agencies.**
-      </p>
-      <label>
-        <p>
-          How many needles are at the location?
-        </p>
-        <select
-          name="SR-NEDRMV1"
-          onInput={[Function]}>
-          <option
-            value="One">
-            One
-          </option>
-          <option
-            value="Two">
-            Two
-          </option>
-          <option
-            value="Three">
-            Three
-          </option>
-          <option
-            value="More than Three">
-            More than Three
-          </option>
-        </select>
-      </label>
-    </div>
-    <div>
-      <h2
-        className={
-          Object {
-            "data-css-16pm9zd": "",
-          }
-        }>
-        CONTACT FORM
-      </h2>
-      <div
-        className={
-          Object {
-            "data-css-1w0rge6": "",
-          }
-        }>
-        (will not be shared with public; leave blank to submit anonymously)
-      </div>
-      <label
-        className={
-          Object {
-            "data-css-12a7iqv": "",
-          }
-        }>
-        <span>
-          First Name (required)
-        </span>
-        <input
-          className={
-            Object {
-              "data-css-b35x0h": "",
-            }
-          }
-          name="firstName"
-          onChange={[Function]}
-          placeholder="First Name"
-          value="" />
-      </label>
-      <label
-        className={
-          Object {
-            "data-css-12a7iqv": "",
-          }
-        }>
-        <span>
-          Last Name (required)
-        </span>
-        <input
-          className={
-            Object {
-              "data-css-b35x0h": "",
-            }
-          }
-          name="lastName"
-          onChange={[Function]}
-          placeholder="Last Name"
-          value="" />
-      </label>
-      <label
-        className={
-          Object {
-            "data-css-12a7iqv": "",
-          }
-        }>
-        <span>
-          Email (required)
-        </span>
-        <input
-          className={
-            Object {
-              "data-css-b35x0h": "",
-            }
-          }
-          name="email"
-          onChange={[Function]}
-          placeholder="Email"
-          type="email"
-          value="" />
-      </label>
-      <label
-        className={
-          Object {
-            "data-css-12a7iqv": "",
-          }
-        }>
-        <span>
-          Phone
-        </span>
-        <input
-          className={
-            Object {
-              "data-css-b35x0h": "",
-            }
-          }
-          name="phone"
-          onChange={[Function]}
-          placeholder="Phone"
-          type="tel"
-          value="" />
-      </label>
-    </div>
-    <button
-      disabled={true}
-      onClick={[Function]}>
-      Submit
-    </button>
-  </div>
+    }
+    loopbackGraphql={[Function]}
+    showServiceForm={[Function]} />
+</div>
+`;
+
+exports[`service page exists rendering 1`] = `
+<div>
+  <SideEffect(Head)>
+    <title>
+      BOS:311 — 
+      Cosmic Incursion
+    </title>
+  </SideEffect(Head)>
+  <ReportLayout
+    goToReportForm={[Function]}
+    initialProps={
+      Object {
+        "code": "CSMCINC",
+        "pickLocation": false,
+        "service": Object {
+          "code": "CSMCINC",
+          "hasMetadata": false,
+          "metadata": null,
+          "name": "Cosmic Incursion",
+        },
+        "view": "service",
+      }
+    }
+    loopbackGraphql={[Function]}
+    showServiceForm={[Function]} />
+</div>
+`;
+
+exports[`service page not found rendering 1`] = `
+<div>
+  <SideEffect(Head)>
+    <title>
+      BOS:311 — 
+      Not found
+    </title>
+  </SideEffect(Head)>
+  <ReportLayout
+    goToReportForm={[Function]}
+    initialProps={
+      Object {
+        "code": "CSMCINC",
+        "pickLocation": false,
+        "service": null,
+        "view": "service",
+      }
+    }
+    loopbackGraphql={[Function]}
+    showServiceForm={[Function]} />
 </div>
 `;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,8 +1,31 @@
+// @flow
 /* eslint react/no-danger: 0 */
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
+import { renderStatic } from 'glamor/server';
+
+type Props = {
+  __NEXT_DATA__: Object,
+  ids: string[],
+  css: string,
+};
 
 export default class extends Document {
+  static async getInitialProps({ renderPage }) {
+    const page = renderPage();
+    const styles = renderStatic(() => page.html);
+    return { ...page, ...styles };
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    const { __NEXT_DATA__, ids } = props;
+    if (ids) {
+      __NEXT_DATA__.ids = this.props.ids;
+    }
+  }
+
   render() {
     return (
       <html lang="en">
@@ -23,6 +46,8 @@ export default class extends Document {
               box-sizing: border-box
             }
           `}</style>
+
+          <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
 
         <body>

--- a/pages/report.test.js
+++ b/pages/report.test.js
@@ -1,24 +1,27 @@
 // @flow
+/* eslint no-fallthrough: 0 */
 
 import React from 'react';
-import renderer from 'react-test-renderer';
+import ReactTestUtils from 'react-addons-test-utils';
 
-import Report from './report';
+// Named rather than default import so we don't have the withStore wrapper that
+// obscures types.
+import { Report } from './report';
 
 import { makeServerContext } from '../lib/test/make-context';
-import inBrowser from '../lib/test/in-browser';
 import makeLoopbackGraphql from '../data/graphql/loopback-graphql';
 
 import LoadServiceSummariesGraphql from '../data/graphql/LoadServiceSummaries.graphql';
 import LoadServiceGraphql from '../data/graphql/LoadService.graphql';
 import type { LoadServiceSummariesQuery, LoadServiceQuery } from '../data/graphql/schema.flow';
+import type { InitialProps } from '../components/layouts/ReportLayout';
 
 jest.mock('../data/graphql/loopback-graphql');
 
 const MOCK_SERVICE_SUMMARIES_RESPONSE: LoadServiceSummariesQuery = {
   services: [{
-    name: 'Needle Pickup',
-    code: 'needles',
+    name: 'Cosmic Incursion',
+    code: 'CSMCINC',
     hasMetadata: true,
     locationRequired: true,
   }],
@@ -26,61 +29,132 @@ const MOCK_SERVICE_SUMMARIES_RESPONSE: LoadServiceSummariesQuery = {
 
 const MOCK_SERVICE_RESPONSE: LoadServiceQuery = {
   service: {
-    name: 'Needle Pickup',
-    code: 'needles',
-    hasMetadata: true,
-    metadata: {
-      attributes: [{
-        required: false,
-        type: 'TEXT',
-        code: 'ST-CMTS',
-        description: 'Please provide any other relevant information:',
-        values: null,
-      }, {
-        required: false,
-        type: 'STRING',
-        code: 'INFO-NEDRMV1',
-        description: '**All needle pickup cases should be followed up with a phone call to one of the below agencies.**',
-        values: null,
-      }, {
-        required: true,
-        type: 'SINGLEVALUELIST',
-        code: 'SR-NEDRMV1',
-        description: 'How many needles are at the location?',
-        values: [{ key: 'One', name: 'One' }, { key: 'Two', name: 'Two' }, { key: 'Three', name: 'Three' }, { key: 'More than Three', name: 'More than Three' }],
-      }],
-    },
+    name: 'Cosmic Incursion',
+    code: 'CSMCINC',
+    hasMetadata: false,
+    metadata: null,
   },
 };
 
-test('request flow', async () => {
+const MOCK_MISSING_SERVICE_RESPONSE: LoadServiceQuery = {
+  service: null,
+};
+
+const shallowRenderer = ReactTestUtils.createRenderer();
+
+function mockGraphql(query, value) {
   // check to make Flow happy
   if (typeof makeLoopbackGraphql.mockResponse === 'function') {
-    makeLoopbackGraphql.mockResponse(LoadServiceSummariesGraphql, MOCK_SERVICE_SUMMARIES_RESPONSE);
+    makeLoopbackGraphql.mockResponse(query, value);
   }
+}
 
-  const ctx = makeServerContext('/report');
-  const initialProps = await Report.getInitialProps(ctx);
+describe('report form', () => {
+  let ctx;
 
-  await inBrowser(async () => {
-    const component = renderer.create(<Report {...initialProps} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  beforeEach(() => {
+    mockGraphql(LoadServiceSummariesGraphql, MOCK_SERVICE_SUMMARIES_RESPONSE);
+    ctx = makeServerContext('/report');
+  });
+
+  test('getInitialProps', async () => {
+    const initialProps: InitialProps = await Report.getInitialProps(ctx);
+
+    switch (initialProps.view) {
+      case 'summaries':
+        expect(initialProps.serviceSummaries).toHaveLength(1);
+      default:
+        expect(initialProps.view).toEqual('summaries');
+    }
+  });
+
+  test('rendering', async () => {
+    const initialProps: InitialProps = await Report.getInitialProps(ctx);
+    expect(shallowRenderer.render(<Report {...initialProps} />)).toMatchSnapshot();
   });
 });
 
-test('service page', async () => {
-  // check to make Flow happy
-  if (typeof makeLoopbackGraphql.mockResponse === 'function') {
-    makeLoopbackGraphql.mockResponse(LoadServiceGraphql, MOCK_SERVICE_RESPONSE);
-  }
+describe('service page', () => {
+  let ctx;
 
-  const ctx = makeServerContext('/report', { code: 'needles' });
-  const initialProps = await Report.getInitialProps(ctx);
+  beforeEach(() => {
+    ctx = makeServerContext('/report', { code: 'CSMCINC' });
+  });
 
-  await inBrowser(async () => {
-    const component = renderer.create(<Report {...initialProps} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  describe('exists', () => {
+    beforeEach(() => {
+      mockGraphql(LoadServiceGraphql, MOCK_SERVICE_RESPONSE);
+    });
+
+    test('getInitialProps', async () => {
+      const initialProps = await Report.getInitialProps(ctx);
+
+      switch (initialProps.view) {
+        case 'service':
+          expect(initialProps.service).toBeDefined();
+          expect(initialProps.pickLocation).toEqual(false);
+        default:
+          expect(initialProps.view).toEqual('service');
+      }
+    });
+
+    test('rendering', async () => {
+      const initialProps = await Report.getInitialProps(ctx);
+      expect(shallowRenderer.render(<Report {...initialProps} />)).toMatchSnapshot();
+    });
+  });
+
+  describe('not found', () => {
+    beforeEach(() => {
+      mockGraphql(LoadServiceGraphql, MOCK_MISSING_SERVICE_RESPONSE);
+    });
+
+    test('getInitialProps', async () => {
+      const initialProps = await Report.getInitialProps(ctx);
+
+      if (ctx.res) {
+        expect(ctx.res.statusCode).toEqual(404);
+      } else {
+        expect(ctx.res).toBeDefined();
+      }
+
+      switch (initialProps.view) {
+        case 'service':
+          expect(initialProps.service).toBeNull();
+        default:
+          expect(initialProps.view).toEqual('service');
+      }
+    });
+
+    test('rendering', async () => {
+      const initialProps = await Report.getInitialProps(ctx);
+      expect(shallowRenderer.render(<Report {...initialProps} />)).toMatchSnapshot();
+    });
+  });
+});
+
+describe('location picker', () => {
+  let ctx;
+
+  beforeEach(() => {
+    mockGraphql(LoadServiceGraphql, MOCK_SERVICE_RESPONSE);
+    ctx = makeServerContext('/report', { code: 'CSMCINC', pickLocation: 'true' });
+  });
+
+  test('getInitialProps', async () => {
+    const initialProps = await Report.getInitialProps(ctx);
+
+    switch (initialProps.view) {
+      case 'service':
+        expect(initialProps.service).toBeDefined();
+        expect(initialProps.pickLocation).toEqual(true);
+      default:
+        expect(initialProps.view).toEqual('service');
+    }
+  });
+
+  test('rendering', async () => {
+    const initialProps = await Report.getInitialProps(ctx);
+    expect(shallowRenderer.render(<Report {...initialProps} />)).toMatchSnapshot();
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -106,6 +106,12 @@ const port = parseInt(process.env.PORT || '3000', 10);
 
   server.route({
     method: 'GET',
+    path: '/on-demand-entries-ping',
+    handler: nextDefaultHandler(app),
+  });
+
+  server.route({
+    method: 'GET',
     path: '/__webpack_hmr',
     handler: nextDefaultHandler(app),
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,6 @@ ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-html@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.6.tgz#bda8e33dd2ee1c20f54c08eb405713cbfc0ed80e"
-
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -1893,9 +1889,9 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
-cross-spawn@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.0.1.tgz#a3bbb302db2297cbea3c04edf36941f4613aa399"
+cross-spawn@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
@@ -2844,9 +2840,9 @@ fresh@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
-friendly-errors-webpack-plugin@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.3.1.tgz#80ab4ab26bfa733cae576dd0d427c64056781fdc"
+friendly-errors-webpack-plugin@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.4.0.tgz#d1cec96387c7586122202e8a946e4e66baf2c102"
   dependencies:
     chalk "^1.1.3"
     error-stack-parser "^2.0.0"
@@ -2936,7 +2932,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glamor@2.20.23, glamor@^2.20.22:
+glamor@^2.20.22:
   version "2.20.23"
   resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.23.tgz#aa597b9b0e8835258d0655b19687dc4e772e6c49"
   dependencies:
@@ -4025,7 +4021,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@0.2.16, loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
+loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
   dependencies:
@@ -4033,6 +4029,14 @@ loader-utils@0.2.16, loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.2.tgz#a9f923c865a974623391a8602d031137fad74830"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
@@ -4383,9 +4387,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-next@2.0.0-beta.31:
-  version "2.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/next/-/next-2.0.0-beta.31.tgz#e8016911bb3dcfbc9d2b4e6f21ffe04e9354706d"
+next@beta:
+  version "2.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/next/-/next-2.0.0-beta.33.tgz#0ead91fef47ce440a89a70f94ff5b6ec14d2d2d6"
   dependencies:
     ansi-html "0.0.7"
     babel-core "6.23.1"
@@ -4403,16 +4407,15 @@ next@2.0.0-beta.31:
     babel-preset-react "6.23.0"
     babel-runtime "6.23.0"
     case-sensitive-paths-webpack-plugin "1.1.4"
-    cross-spawn "5.0.1"
+    cross-spawn "5.1.0"
     del "2.2.2"
-    friendly-errors-webpack-plugin "1.3.1"
-    glamor "2.20.23"
+    friendly-errors-webpack-plugin "1.4.0"
     glob-promise "3.1.0"
     htmlescape "1.1.1"
     http-status "1.0.1"
     is-windows-bash "1.0.3"
     json-loader "0.5.4"
-    loader-utils "0.2.16"
+    loader-utils "1.0.2"
     minimist "1.2.0"
     mkdirp-then "1.2.0"
     mv "2.1.1"
@@ -4423,13 +4426,14 @@ next@2.0.0-beta.31:
     send "0.14.1"
     source-map-support "0.4.11"
     strip-ansi "3.0.1"
-    styled-jsx "0.5.6"
+    styled-jsx "0.5.7"
+    touch "1.0.0"
+    unfetch "2.1.0"
     url "0.11.0"
     uuid "3.0.1"
     webpack "2.2.1"
-    webpack-dev-middleware "1.10.0"
-    webpack-hot-middleware "2.17.0"
-    whatwg-fetch "2.0.2"
+    webpack-dev-middleware "1.10.1"
+    webpack-hot-middleware "2.17.1"
     write-file-webpack-plugin "3.4.2"
 
 nigel@2.x.x:
@@ -4549,6 +4553,12 @@ node-pre-gyp@^0.6.29:
     semver "~5.3.0"
     tar "~2.2.1"
     tar-pack "~3.3.0"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
 
 nopt@~3.0.6:
   version "3.0.6"
@@ -5351,6 +5361,13 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
+react-addons-test-utils@^15.4.2:
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
+
 react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
@@ -6141,9 +6158,9 @@ style-loader@0.13.1:
   dependencies:
     loader-utils "^0.2.7"
 
-styled-jsx@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-0.5.6.tgz#fa7aa71061a8a2b6cbbb55af3628c8e8acbeeea9"
+styled-jsx@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-0.5.7.tgz#2cb02263ffa719b1435a864fdd6c62802ae86669"
   dependencies:
     babel-plugin-syntax-jsx "6.18.0"
     babel-traverse "6.21.0"
@@ -6312,6 +6329,12 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
+touch@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
+  dependencies:
+    nopt "~1.0.10"
+
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -6379,6 +6402,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+unfetch@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-2.1.0.tgz#721b9eb7742a71c6dbf85d7f9d9412f3f7c6a20d"
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -6568,20 +6595,20 @@ webpack-core@~0.6.9:
     source-list-map "~0.1.7"
     source-map "~0.4.1"
 
-webpack-dev-middleware@1.10.0, webpack-dev-middleware@^1.6.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz#7d5be2651e692fddfafd8aaed177c16ff51f0eb8"
+webpack-dev-middleware@1.10.1, webpack-dev-middleware@^1.6.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz#c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893"
   dependencies:
     memory-fs "~0.4.1"
     mime "^1.3.4"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-hot-middleware@2.17.0, webpack-hot-middleware@^2.13.2:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.17.0.tgz#5af55fd2bc2f9a4392edd553f2a0fbebd4d75e78"
+webpack-hot-middleware@2.17.1, webpack-hot-middleware@^2.13.2:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.17.1.tgz#0c8fbf6f93ff29c095d684b07ab6d6c0f2f951d7"
   dependencies:
-    ansi-html "0.0.6"
+    ansi-html "0.0.7"
     html-entities "^1.2.0"
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
@@ -6644,7 +6671,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@2.0.2, whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
 


### PR DESCRIPTION
 - Adds back in Glamor to _document
 - Splits report page to "require" ReportLayout to allow for glamor
   hydration before ES2015 imports
 - Adds explicit test coverage for withStore