### PR TITLE
Adds a client-side cache of services to the store

### DIFF
--- a/components/report/ReportLayout.test.js
+++ b/components/report/ReportLayout.test.js
@@ -129,6 +129,18 @@ describe('existing service page', () => {
     }
   });
 
+  test('service is cached', async () => {
+    // store should have the service cached by code from the beforeEach above,
+    // so to enforce that we're not fetching a second time we clear this out
+    // of the fake GraphQL responses.
+    mockGraphql(LoadServiceGraphql, null);
+
+    const ctx = makeServerContext('/report', { code: 'CSMCINC' });
+    const nextData = (await ReportLayout.getInitialProps(ctx, store)).data;
+
+    expect(nextData).toEqual(data);
+  });
+
   test('rendering', () => {
     const component = renderer.create(
       <Provider store={store}>

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -6,16 +6,19 @@ import type { Store as ReduxStore, Reducer, Dispatch as ReduxDispatch } from 're
 
 import keys from './keys';
 import request from './request';
+import services from './services';
 
 import type { State as KeysState, Action as KeysAction } from './keys';
 import type { State as RequestState, Action as RequestAction } from './request';
+import type { State as ServicesState, Action as ServicesAction } from './services';
 
 export type State = {|
   keys: KeysState,
   request: RequestState,
+  services: ServicesState,
 |};
 
-export type Action = KeysAction | RequestAction;
+export type Action = KeysAction | RequestAction | ServicesAction;
 export type Dispatch = ReduxDispatch<Action>;
 
 export type Store = ReduxStore<State, Action>;
@@ -30,6 +33,7 @@ export function makeStore(initialState: ?State = undefined): Store {
   const reducer: Reducer<State, Action> = combineReducers({
     keys,
     request,
+    services,
   });
 
   // Support for Redux Devtools Extension: https://github.com/zalmoxisus/redux-devtools-extension

--- a/data/store/index.test.js
+++ b/data/store/index.test.js
@@ -32,6 +32,9 @@ describe('getStore', () => {
         location: null,
         phone: '',
       },
+      services: {
+        cache: {},
+      },
     };
     const store = getStore(initialState);
     expect(store.getState()).toEqual(initialState);

--- a/data/store/services.js
+++ b/data/store/services.js
@@ -1,0 +1,33 @@
+// @flow
+
+import type { Service } from '../types';
+
+export type Action =
+  {| type: 'SERVICE_ADD_SERVICE_TO_CACHE', payload: Service |}
+
+export type State = {
+  cache: {[code: string]: Service}
+}
+
+export const addServiceToCache = (service: Service): Action => ({
+  type: 'SERVICE_ADD_SERVICE_TO_CACHE',
+  payload: service,
+});
+
+export const DEFAULT_STATE = {
+  cache: {},
+};
+
+export function selectCachedService(state: State, code: string): ?Service {
+  return state.cache[code] || null;
+}
+
+export default function reducer(state: State = DEFAULT_STATE, action: Action): State {
+  switch (action.type) {
+    case 'SERVICE_ADD_SERVICE_TO_CACHE': {
+      const { code } = action.payload;
+      return { ...state, cache: { ...state.cache, [code]: action.payload } };
+    }
+    default: return state;
+  }
+}

--- a/data/store/services.test.js
+++ b/data/store/services.test.js
@@ -1,0 +1,33 @@
+// @flow
+
+import type { Service } from '../types';
+
+import reducer, {
+  DEFAULT_STATE,
+  addServiceToCache,
+} from './services';
+
+const COSMIC_SERVICE: Service = {
+  name: 'Cosmic Incursion',
+  code: 'CSMCINC',
+  hasMetadata: true,
+  metadata: {
+    attributes: [{
+      required: false,
+      type: 'TEXT',
+      code: 'ST-CMTS',
+      description: 'Please provide any other relevant information:',
+      values: null,
+    }],
+  },
+};
+
+
+describe('addServiceToCache', () => {
+  it('adds the service to the cache', () => {
+    let state = DEFAULT_STATE;
+    state = reducer(state, addServiceToCache(COSMIC_SERVICE));
+    const cache = state.cache;
+    expect(cache.CSMCINC).toEqual(COSMIC_SERVICE);
+  });
+});


### PR DESCRIPTION
Keeps navigation across steps fast because the browser doesn't go back
to the server for service metadata on every page.