### PR TITLE
Adds error boundary around interpreting questions

### DIFF
--- a/components/report/__snapshots__/ReportLayout.test.js.snap
+++ b/components/report/__snapshots__/ReportLayout.test.js.snap
@@ -338,7 +338,7 @@ exports[`report form rendering 1`] = `
                   "data-css-3br7c8": "",
                 }
               }
-              href="/report/CSMCINC/location"
+              href="/report/CSMCINC"
               onClick={[Function]}
             >
               Cosmic Incursion

--- a/components/report/home/ServiceList.js
+++ b/components/report/home/ServiceList.js
@@ -53,7 +53,7 @@ class ServiceButton extends React.Component {
     const { serviceSummary: { code, name } } = this.props;
     return (
       <li className={STYLES.item} key={code}>
-        <a className={STYLES.link} href={`/report/${code}/location`} onClick={this.whenClicked}>{name}</a>
+        <a className={STYLES.link} href={`/report/${code}`} onClick={this.whenClicked}>{name}</a>
       </li>
     );
   }

--- a/components/report/home/__snapshots__/ServiceList.test.js.snap
+++ b/components/report/home/__snapshots__/ServiceList.test.js.snap
@@ -21,7 +21,7 @@ exports[`services 1`] = `
           "data-css-3br7c8": "",
         }
       }
-      href="/report/CSMCINC/location"
+      href="/report/CSMCINC"
       onClick={[Function]}
     >
       Cosmic Incursion

--- a/components/report/request/RequestDialog.js
+++ b/components/report/request/RequestDialog.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import Head from 'next/head';
 import { observable, action } from 'mobx';
+import ScopedError from 'react-scoped-error-component';
 import { observer } from 'mobx-react';
 import { fromPromise } from 'mobx-utils';
 import type { IPromiseBasedObservable } from 'mobx-utils';
@@ -130,7 +131,7 @@ export default class RequestDialog extends React.Component {
 
   renderContent() {
     const { store, stage, locationMapSearch } = this.props;
-    const { currentService } = store;
+    const { currentService, currentServiceError } = store;
 
     if (this.submission) {
       switch (this.submission.state) {
@@ -143,6 +144,15 @@ export default class RequestDialog extends React.Component {
 
     if (!currentService) {
       return <SectionHeader>Service not found</SectionHeader>;
+    }
+
+    if (currentServiceError) {
+      return (
+        <div>
+          <SectionHeader>Error loading service</SectionHeader>
+          <ScopedError error={currentServiceError} />
+        </div>
+      );
     }
 
     switch (stage) {

--- a/components/report/request/RequestDialog.test.js
+++ b/components/report/request/RequestDialog.test.js
@@ -8,7 +8,6 @@ import RequestDialog from './RequestDialog';
 import type { Service } from '../../../data/types';
 import { AppStore } from '../../../data/store';
 
-import { GraphQLError } from '../../../data/graphql/loopback-graphql';
 import type { SubmitRequestMutation } from '../../../data/graphql/schema.flow';
 
 const MOCK_SERVICE: Service = {
@@ -162,10 +161,13 @@ describe('methods', () => {
     test('graphql failure', async () => {
       const submission = requestDialog.submitRequest();
 
-      rejectGraphql(new GraphQLError('Error submitting', [
+      const error: Object = new Error('Error submitting');
+      error.errors = [
         { message: 'All required fields were missing' },
         { message: 'Also your location is in Cambridge' },
-      ]));
+      ];
+
+      rejectGraphql(error);
 
       try {
         await submission;

--- a/components/report/request/SubmitPane.js
+++ b/components/report/request/SubmitPane.js
@@ -4,7 +4,6 @@ import React from 'react';
 import SectionHeader from '../../common/SectionHeader';
 
 import type { SubmittedRequest } from '../../../data/types';
-import { GraphQLError } from '../../../data/graphql/loopback-graphql';
 
 export type Props = {
   state: 'submitting',
@@ -30,8 +29,8 @@ export default function SubmitPane(props: Props) {
       return (
         <div>
           <SectionHeader>Submission Error</SectionHeader>
-          { error instanceof GraphQLError && error.errors.map((e, i) => <p key={i}>{e.message}</p>) }
-          { !(error instanceof GraphQLError) && (error.message ? error.message : error.toString()) }
+          { Array.isArray(error.errors) && error.errors.map((e, i) => <p key={i}>{e.message}</p>) }
+          { !Array.isArray(error.errors) && (error.message ? error.message : error.toString()) }
         </div>
       );
     }

--- a/components/report/request/SubmitPane.stories.js
+++ b/components/report/request/SubmitPane.stories.js
@@ -3,9 +3,14 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 
-import { GraphQLError } from '../../../data/graphql/loopback-graphql';
 import SubmitPane from './SubmitPane';
 import FormDialog from '../../common/FormDialog';
+
+const makeError = (message, errors) => {
+  const error: Object = new Error(message);
+  error.errors = errors;
+  return error;
+};
 
 storiesOf('SubmitPane', module)
 .addDecorator((story) => (
@@ -20,7 +25,7 @@ storiesOf('SubmitPane', module)
 .add('GraphQL Error', () => (
   <SubmitPane
     state="error"
-    error={new GraphQLError('GraphQL Server Error', [
+    error={makeError('GraphQL Server Error', [
       { message: 'firstName is a required field' },
       { message: 'lastName is a required field' },
     ])}

--- a/components/report/request/__snapshots__/RequestDialog.test.js.snap
+++ b/components/report/request/__snapshots__/RequestDialog.test.js.snap
@@ -16,19 +16,7 @@ exports[`methods submitRequest graphql failure 1`] = `
   </SideEffect(Head)>
   <FormDialog>
     <SubmitPane
-      error={
-        GraphQLError {
-          "errors": Array [
-            Object {
-              "message": "All required fields were missing",
-            },
-            Object {
-              "message": "Also your location is in Cambridge",
-            },
-          ],
-          "message": "Error submitting",
-        }
-      }
+      error={[Error: Error submitting]}
       state="error"
     />
   </FormDialog>

--- a/data/graphql/loopback-graphql.js
+++ b/data/graphql/loopback-graphql.js
@@ -6,19 +6,15 @@ import type { RequestAdditions } from '../../server/next-handlers';
 type QueryVariables = { [key: string]: any };
 export type LoopbackGraphql = (query: string, variables: ?QueryVariables) => Promise<Object>;
 
-export type GraphQLQueryError = {|
-  message: string;
-|};
-
-export class GraphQLError {
-  message: string;
-  errors: GraphQLQueryError[];
-
-  constructor(message: string, errors: ?GraphQLQueryError[]) {
-    this.message = message || 'GraphQL server error';
-    this.errors = errors || [];
+const makeGraphQLError = (message, errors) => {
+  if (!message) {
+    message = `[Server] ${errors.map((e) => e.message).join(', ')}`;
   }
-}
+
+  const e: Object = new Error(message);
+  e.errors = errors;
+  return e;
+};
 
 /**
  * Given a bit that's true if the response was a 200, and a parsed JSON
@@ -30,7 +26,7 @@ function handleGraphqlResponse(ok, json) {
   if (ok && !json.errors) {
     return json.data;
   } else {
-    throw new GraphQLError(json.message, json.errors);
+    throw makeGraphQLError(json.message, json.errors);
   }
 }
 

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -52,6 +52,7 @@ export class AppStore {
   apiKeys: {[service: string]: string} = {};
 
   @observable.ref _currentService: ?Service = null;
+  @observable.ref currentServiceError: ?Object = null;
 
   @computed get currentService(): ?Service {
     return this._currentService;
@@ -63,10 +64,17 @@ export class AppStore {
     }
 
     this._currentService = service;
+    this.currentServiceError = null;
+    this.questions = [];
+
     if (service) {
-      this.contactInfo.required = service.contactRequired;
-      this.locationInfo.required = service.locationRequired;
-      this.questions = Question.buildQuestions(service.attributes);
+      try {
+        this.contactInfo.required = service.contactRequired;
+        this.locationInfo.required = service.locationRequired;
+        this.questions = Question.buildQuestions(service.attributes);
+      } catch (e) {
+        this.currentServiceError = e;
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "next": "2.0.0-beta.36",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-scoped-error-component": "^0.9.1",
     "url-search-params": "^0.6.1"
   },
   "devDependencies": {

--- a/server/graphql/service.js
+++ b/server/graphql/service.js
@@ -160,8 +160,8 @@ export const resolvers = {
     code: (s: Service) => s.service_code,
     name: (s: Service) => s.service_name || '',
     attributes: makeMetadataResolver((metadata: ?ServiceMetadata) => (metadata ? metadata.attributes : [])),
-    locationRequired: makeMetadataResolver((metadata: ?ServiceMetadata) => (metadata ? metadata.definitions.location_required : true)),
-    contactRequired: makeMetadataResolver((metadata: ?ServiceMetadata) => (metadata ? metadata.definitions.contact_required : true)),
+    locationRequired: makeMetadataResolver((metadata: ?ServiceMetadata) => (metadata && metadata.definitions ? metadata.definitions.location_required : true)),
+    contactRequired: makeMetadataResolver((metadata: ?ServiceMetadata) => (metadata && metadata.definitions ? metadata.definitions.contact_required : true)),
   },
 
   ServiceAttribute: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,6 +5700,12 @@ react-proxy@^3.0.0-alpha.0:
   dependencies:
     lodash "^4.6.1"
 
+react-scoped-error-component@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/react-scoped-error-component/-/react-scoped-error-component-0.9.1.tgz#89068bba73b36afc3a2586885e226236f0eaa1bc"
+  dependencies:
+    redbox-react "^1.2.0"
+
 react-simple-di@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-simple-di/-/react-simple-di-1.2.0.tgz#dde0e5bf689f391ef2ab02c9043b213fe239c6d0"
@@ -5805,7 +5811,7 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-redbox-react@^1.2.5:
+redbox-react@^1.2.0, redbox-react@^1.2.5:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.3.3.tgz#63ec9c2cb9c620c46e2b9f8543b4898f1b787e41"
   dependencies:


### PR DESCRIPTION
Keeps exceptions when generating questions from crashing the whole app.

Improves error display for GraphQL errors that occur during
getInitialProps by removing GraphQLError in favor of an Error object.

Also adds a DataLoader around metadata to prevent the multiple requests
introduced by the last PR.