### PR TITLE
Disables map click during drag

### DIFF
--- a/components/report/home/RecentRequests.test.js
+++ b/components/report/home/RecentRequests.test.js
@@ -31,7 +31,7 @@ describe('rendering', () => {
 
   beforeEach(() => {
     store = new AppStore();
-    store.requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    store.requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
   });
 
   test('results loaded', () => {

--- a/components/report/map/SearchMarkerPool.test.js
+++ b/components/report/map/SearchMarkerPool.test.js
@@ -65,7 +65,7 @@ afterEach(() => {
 
 describe('generation', () => {
   test('request with location', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
 
     const marker = createdMarkers[0];
     expect(marker).toBeDefined();
@@ -75,24 +75,24 @@ describe('generation', () => {
   });
 
   test('request without location', () => {
-    requestSearch.update({ requests: [{ ...MOCK_REQUEST, location: null }], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [{ ...MOCK_REQUEST, location: null }], query: '' });
     expect(createdMarkers.length).toEqual(0);
   });
 
   it('caches markers', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     expect(createdMarkers.length).toEqual(1);
 
-    requestSearch.update({ requests: [{ ...MOCK_REQUEST }], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [{ ...MOCK_REQUEST }], query: '' });
     // new Marker was not created
     expect(createdMarkers.length).toEqual(1);
   });
 
   it('disposes of old markers', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     const marker = createdMarkers[0];
 
-    requestSearch.update({ requests: [{ ...MOCK_REQUEST, id: 'new-request-id' }], query: 'new query' });
+    requestSearch.updateRequestSearchResults({ requests: [{ ...MOCK_REQUEST, id: 'new-request-id' }], query: 'new query' });
     // new Marker was created
     expect(createdMarkers.length).toEqual(2);
     expect(map.hasLayer(marker)).toEqual(false);
@@ -101,13 +101,13 @@ describe('generation', () => {
 
 describe('opacity update', () => {
   it('sets a map', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     const marker = createdMarkers[0];
     expect(map.hasLayer(marker)).toEqual(true);
   });
 
   it('clears the map', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     const marker = createdMarkers[0];
     opacityBox.set(0);
     expect(marker.options.opacity).toEqual(0);
@@ -117,7 +117,7 @@ describe('opacity update', () => {
 
 describe('icon update', () => {
   it('sets an icon', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     const marker = createdMarkers[0];
     if (!marker.options.icon) {
       expect(marker.options.icon).toBeDefined();
@@ -127,7 +127,7 @@ describe('icon update', () => {
   });
 
   it('sets a closed icon', () => {
-    requestSearch.update({ requests: [{ ...MOCK_REQUEST, status: 'closed' }], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [{ ...MOCK_REQUEST, status: 'closed' }], query: '' });
     const marker = createdMarkers[0];
     if (!marker.options.icon) {
       expect(marker.options.icon).toBeDefined();
@@ -137,7 +137,7 @@ describe('icon update', () => {
   });
 
   it('updates to hover when selected', () => {
-    requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
     const marker = createdMarkers[0];
 
     requestSearch.selectedRequest = MOCK_REQUEST;
@@ -149,7 +149,7 @@ describe('icon update', () => {
   });
 
   it('updates to hover when selected', () => {
-    requestSearch.update({ requests: [{ ...MOCK_REQUEST, status: 'closed' }], query: '' });
+    requestSearch.updateRequestSearchResults({ requests: [{ ...MOCK_REQUEST, status: 'closed' }], query: '' });
     const marker = createdMarkers[0];
 
     requestSearch.selectedRequest = MOCK_REQUEST;
@@ -162,7 +162,7 @@ describe('icon update', () => {
 });
 
 test('click handler', () => {
-  requestSearch.update({ requests: [MOCK_REQUEST], query: '' });
+  requestSearch.updateRequestSearchResults({ requests: [MOCK_REQUEST], query: '' });
   const marker = createdMarkers[0];
 
   expect(requestSearch.selectedRequest).toEqual(null);

--- a/data/store/RequestSearch.js
+++ b/data/store/RequestSearch.js
@@ -33,7 +33,7 @@ export default class RequestSearch {
   searchDisposer: ?Function = null;
 
   @action.bound
-  update({ requests, query }: SearchRequestsPage) {
+  updateRequestSearchResults({ requests, query }: SearchRequestsPage) {
     // In this method we want to bring in the new requests, but preserve any
     // existing ones that match the location / query. Without this, moving
     // across the map could make requests disappear if they are not in the top
@@ -60,7 +60,7 @@ export default class RequestSearch {
   start(loopbackGraphql: LoopbackGraphql) {
     this.searching = false;
     this.searchPending = false;
-    this.searchDisposer = autorun(this.search.bind(this, loopbackGraphql));
+    this.searchDisposer = autorun('RequestSearch auto-search', this.search.bind(this, loopbackGraphql));
   }
 
   stop() {
@@ -84,14 +84,14 @@ export default class RequestSearch {
     this.searching = true;
     this.searchPending = false;
 
-    const searchComplete = action(() => {
+    const searchComplete = action('search complete', () => {
       this.searching = false;
       if (this.searchPending) {
         this.search(loopbackGraphql);
       }
     });
 
-    searchRequests(loopbackGraphql, query, mapCenter, radiusKm).then(this.update).then(searchComplete, (e) => {
+    searchRequests(loopbackGraphql, query, mapCenter, radiusKm).then(this.updateRequestSearchResults).then(searchComplete, (e) => {
       searchComplete();
       throw e;
     });

--- a/data/store/RequestSearch.test.js
+++ b/data/store/RequestSearch.test.js
@@ -36,13 +36,13 @@ beforeEach(() => {
 
 describe('update', () => {
   it('sets the results', () => {
-    requestSearch.update(MOCK_SEARCH_RESULTS_PAGE);
+    requestSearch.updateRequestSearchResults(MOCK_SEARCH_RESULTS_PAGE);
     expect(requestSearch.results[0]).toEqual(MOCK_REQUEST);
   });
 
   it('merges old results in', () => {
-    requestSearch.update(MOCK_SEARCH_RESULTS_PAGE);
-    requestSearch.update({ ...MOCK_SEARCH_RESULTS_PAGE,
+    requestSearch.updateRequestSearchResults(MOCK_SEARCH_RESULTS_PAGE);
+    requestSearch.updateRequestSearchResults({ ...MOCK_SEARCH_RESULTS_PAGE,
       requests: [{
         ...MOCK_REQUEST,
         id: 'new-id',
@@ -54,16 +54,16 @@ describe('update', () => {
   });
 
   it('re-uses existing IDs', () => {
-    requestSearch.update(MOCK_SEARCH_RESULTS_PAGE);
-    requestSearch.update({ ...MOCK_SEARCH_RESULTS_PAGE, requests: [{ ...MOCK_REQUEST }] });
+    requestSearch.updateRequestSearchResults(MOCK_SEARCH_RESULTS_PAGE);
+    requestSearch.updateRequestSearchResults({ ...MOCK_SEARCH_RESULTS_PAGE, requests: [{ ...MOCK_REQUEST }] });
 
     expect(requestSearch.results[0]).toEqual(MOCK_REQUEST);
     expect(requestSearch.results.length).toEqual(1);
   });
 
   it('clears when the query changes', () => {
-    requestSearch.update(MOCK_SEARCH_RESULTS_PAGE);
-    requestSearch.update({ ...MOCK_SEARCH_RESULTS_PAGE,
+    requestSearch.updateRequestSearchResults(MOCK_SEARCH_RESULTS_PAGE);
+    requestSearch.updateRequestSearchResults({ ...MOCK_SEARCH_RESULTS_PAGE,
       requests: [{
         ...MOCK_REQUEST,
         id: 'new-id',
@@ -78,7 +78,7 @@ describe('update', () => {
 
 describe('results', () => {
   it('filters to bounds', () => {
-    requestSearch.update(MOCK_SEARCH_RESULTS_PAGE);
+    requestSearch.updateRequestSearchResults(MOCK_SEARCH_RESULTS_PAGE);
     requestSearch.mapBounds = ({
       contains: () => false,
     }: any);


### PR DESCRIPTION
Prevents bug where the marker gets positioned at the mouse's location,
rather than the marker's anchor.

Also updates names for some MobX things to make debugging clearer.