### PR TITLE
Moves request caching out of Store

### DIFF
--- a/components/report/ReportLayout.test.js
+++ b/components/report/ReportLayout.test.js
@@ -8,7 +8,6 @@ import Router from 'next/router';
 import type { Service, ServiceSummary } from '../../data/types';
 
 import { makeServerContext } from '../../lib/test/make-context';
-import inBrowser from '../../lib/test/in-browser';
 
 import getStore from '../../data/store';
 
@@ -83,12 +82,7 @@ describe('report form', () => {
   });
 
   test('getInitialProps', () => {
-    switch (data.view) {
-      case 'home':
-        expect(data.topServiceSummaries).toHaveLength(1);
-      default:
-        expect(data.view).toEqual('home');
-    }
+    expect(data.view).toEqual('home');
   });
 
   test('rendering', () => {
@@ -107,36 +101,7 @@ describe('existing service page', () => {
   test('getInitialProps', async () => {
     const ctx = makeServerContext('/report', { code: 'CSMCINC' });
     const data = (await ReportLayout.getInitialProps(ctx)).data;
-
-    switch (data.view) {
-      case 'request':
-        expect(data.service).toBeDefined();
-        expect(data.stage).toEqual('questions');
-      default:
-        expect(data.view).toEqual('request');
-    }
-  });
-
-  test('service is cached', async () => {
-    await inBrowser(async () => {
-      store = getStore();
-      let ctx = makeServerContext('/report', { code: 'CSMCINC' });
-      const data = (await ReportLayout.getInitialProps(ctx)).data;
-
-      // store should have the service cached by code from the beforeEach above,
-      // so to enforce that we're not fetching a second time we clear this out
-      loadService.mockClear();
-
-      // caching happens when the layout is created
-      // eslint-disable-next-line no-new
-      new ReportLayout({ data, store });
-
-      ctx = makeServerContext('/report', { code: 'CSMCINC' });
-      const nextData = (await ReportLayout.getInitialProps(ctx)).data;
-
-      expect(nextData).toEqual(data);
-      expect(loadService).not.toHaveBeenCalled();
-    });
+    expect(data.view).toEqual('request');
   });
 
   test('rendering', async () => {
@@ -191,7 +156,7 @@ describe('missing service page', () => {
 
     switch (data.view) {
       case 'request':
-        expect(data.service).toBeNull();
+        expect(data.props.service).toBeNull();
       default:
         expect(data.view).toEqual('request');
     }

--- a/components/report/home/ChooseServicePane.js
+++ b/components/report/home/ChooseServicePane.js
@@ -7,18 +7,16 @@ import Link from 'next/link';
 import type { ServiceSummary } from '../../../data/types';
 
 import SectionHeader from '../../common/SectionHeader';
-import DescriptionBox from '../../common/DescriptionBox';
 
 export type Props = {|
   description: string,
-  handleDescriptionChanged: (ev: SyntheticInputEvent) => mixed,
   suggestedServiceSummaries: ?ServiceSummary[],
 |};
 
-function renderSummaryRow({ code, name, description }: { code: string, name: string, description: ?string }) {
+function renderSummaryRow(problemDescription: string, { code, name, description }: { code: string, name: string, description: ?string }) {
   return (
     <div className="dr" key={code}>
-      <Link href={`/report?code=${code}`} as={`/report/${code}`}><a className="dr-h">
+      <Link href={`/report?code=${code}&description=${encodeURIComponent(problemDescription)}`} as={`/report/${code}`}><a className="dr-h">
         <div className="dr-ic" style={{ transform: 'translateY(-49%) rotateZ(-90deg)' }}><svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25"><path className="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z" /></svg></div>
         <div className="dr-t">{name}</div>
         <div className="dr-st">{description}</div>
@@ -27,8 +25,8 @@ function renderSummaryRow({ code, name, description }: { code: string, name: str
   );
 }
 
-function renderGeneralRequestRow() {
-  return renderSummaryRow({
+function renderGeneralRequestRow(problemDescription: string) {
+  return renderSummaryRow(problemDescription, {
     code: 'BOS311GEN',
     name: 'General Request',
     // TODO(finh): Add something here
@@ -52,7 +50,7 @@ function renderTypeDescription() {
   );
 }
 
-function renderSuggestions(suggestedServiceSummaries: ServiceSummary[]) {
+function renderSuggestions(problemDescription: string, suggestedServiceSummaries: ServiceSummary[]) {
   return (
     <div>
       <div className="t--info m-v300">
@@ -60,19 +58,19 @@ function renderSuggestions(suggestedServiceSummaries: ServiceSummary[]) {
       </div>
 
       <div className="m-v500">
-        { suggestedServiceSummaries.map(renderSummaryRow) }
+        { suggestedServiceSummaries.map((s) => renderSummaryRow(problemDescription, s)) }
       </div>
 
       <div className="t--info m-v300">
         If none of those seem like a good fit, you can submit a General Request.
       </div>
 
-      <div className="m-v500">{renderGeneralRequestRow()}</div>
+      <div className="m-v500">{renderGeneralRequestRow(problemDescription)}</div>
     </div>
   );
 }
 
-function renderNoSuggestions() {
+function renderNoSuggestions(problemDescription: string) {
   return (
     <div>
       <div className="t--info m-v300">
@@ -80,12 +78,12 @@ function renderNoSuggestions() {
         File a General Request and someone will help you out.
       </div>
 
-      <div className="m-v500">{renderGeneralRequestRow()}</div>
+      <div className="m-v500">{renderGeneralRequestRow(problemDescription)}</div>
     </div>
   );
 }
 
-export default function ChooseServicePane({ description, handleDescriptionChanged, suggestedServiceSummaries }: Props) {
+export default function ChooseServicePane({ description, suggestedServiceSummaries }: Props) {
   return (
     <div>
       <Head>
@@ -96,14 +94,8 @@ export default function ChooseServicePane({ description, handleDescriptionChange
 
         <SectionHeader>File a Report</SectionHeader>
 
-        <div className="m-v500">
-          <DescriptionBox
-            minHeight={90}
-            maxHeight={222}
-            text={description}
-            placeholder="Tell us your problem"
-            onInput={handleDescriptionChanged}
-          />
+        <div className="m-v500 t--intro">
+          “{ description }”
         </div>
       </div>
 
@@ -113,9 +105,9 @@ export default function ChooseServicePane({ description, handleDescriptionChange
         </h3>
 
         { !suggestedServiceSummaries && renderLoading() }
-        { suggestedServiceSummaries && suggestedServiceSummaries.length > 0 && renderSuggestions(suggestedServiceSummaries) }
+        { suggestedServiceSummaries && suggestedServiceSummaries.length > 0 && renderSuggestions(description, suggestedServiceSummaries) }
         { suggestedServiceSummaries && suggestedServiceSummaries.length === 0 && description.length === 0 && renderTypeDescription() }
-        { suggestedServiceSummaries && suggestedServiceSummaries.length === 0 && description.length > 0 && renderNoSuggestions() }
+        { suggestedServiceSummaries && suggestedServiceSummaries.length === 0 && description.length > 0 && renderNoSuggestions(description) }
       </div>
     </div>
   );

--- a/components/report/home/ChooseServicePane.stories.js
+++ b/components/report/home/ChooseServicePane.stories.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { storiesOf, action } from '@kadira/storybook';
+import { storiesOf } from '@kadira/storybook';
 import ChooseServicePane from './ChooseServicePane';
 import FormDialog from '../../common/FormDialog';
 
@@ -53,14 +53,14 @@ storiesOf('ChooseServicePane', module)
     <FormDialog narrow noPadding>{story()}</FormDialog>
   ))
   .add('Loading matches', () => (
-    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={null} handleDescriptionChanged={action('Description changed')} />
+    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={null} />
   ))
   .add('Some matches', () => (
-    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={SERVICE_SUMMARIES} handleDescriptionChanged={action('Description changed')} />
+    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={SERVICE_SUMMARIES} />
   ))
   .add('No matches', () => (
-    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={[]} handleDescriptionChanged={action('Description changed')} />
+    <ChooseServicePane description="Dead raccoon on the sidewalk" suggestedServiceSummaries={[]} />
   ))
   .add('No description', () => (
-    <ChooseServicePane description="" suggestedServiceSummaries={[]} handleDescriptionChanged={action('Description changed')} />
+    <ChooseServicePane description="" suggestedServiceSummaries={[]} />
   ));

--- a/components/report/home/ChooseServicePane.test.js
+++ b/components/report/home/ChooseServicePane.test.js
@@ -16,7 +16,7 @@ const SERVICE_SUMMARIES = [{
 describe('rendering', () => {
   test('some suggested summaries', () => {
     const component = renderer.create(
-      <ChooseServicePane description="Thanos is attacking" handleDescriptionChanged={jest.fn()} suggestedServiceSummaries={SERVICE_SUMMARIES} />,
+      <ChooseServicePane description="Thanos is attacking" suggestedServiceSummaries={SERVICE_SUMMARIES} />,
     );
 
     const json = component.toJSON();
@@ -25,7 +25,7 @@ describe('rendering', () => {
 
   test('no suggested summaries', () => {
     const component = renderer.create(
-      <ChooseServicePane description="Thanos is attacking" handleDescriptionChanged={jest.fn()} suggestedServiceSummaries={[]} />,
+      <ChooseServicePane description="Thanos is attacking" suggestedServiceSummaries={[]} />,
     );
 
     const json = component.toJSON();
@@ -34,7 +34,7 @@ describe('rendering', () => {
 
   test('loading', () => {
     const component = renderer.create(
-      <ChooseServicePane description="Thanos is attacking" handleDescriptionChanged={jest.fn()} suggestedServiceSummaries={null} />,
+      <ChooseServicePane description="Thanos is attacking" suggestedServiceSummaries={null} />,
     );
 
     const json = component.toJSON();
@@ -43,7 +43,7 @@ describe('rendering', () => {
 
   test('no description', () => {
     const component = renderer.create(
-      <ChooseServicePane description="" handleDescriptionChanged={jest.fn()} suggestedServiceSummaries={[]} />,
+      <ChooseServicePane description="" suggestedServiceSummaries={[]} />,
     );
 
     const json = component.toJSON();

--- a/components/report/home/HomeDialog.test.js
+++ b/components/report/home/HomeDialog.test.js
@@ -1,12 +1,18 @@
 // @flow
 
 import React from 'react';
+import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
+import { makeServerContext } from '../../../lib/test/make-context';
 import { AppStore } from '../../../data/store';
 import HomeDialog from './HomeDialog';
+import type { InitialProps } from './HomeDialog';
 
+jest.mock('../../../data/dao/load-top-service-summaries');
 jest.mock('../../../data/dao/load-service-suggestions');
+
+const loadTopServiceSummaries: JestMockFn = (require('../../../data/dao/load-top-service-summaries'): any).default;
 const loadServiceSuggestions: JestMockFn = (require('../../../data/dao/load-service-suggestions'): any).default;
 
 jest.mock('lodash/debounce');
@@ -20,6 +26,68 @@ const SERVICE_SUMMARIES = [{
   locationRequired: true,
 }];
 
+beforeEach(() => {
+  // mock implementation always fires, but after a delay
+  debounce.mockImplementation((fn) => (...args) => Promise.resolve().then(fn.bind(null, ...args)));
+});
+
+describe('home page', () => {
+  let initialProps: InitialProps;
+  let store;
+  let loopbackGraphql;
+
+  beforeEach(async () => {
+    store = new AppStore();
+    loopbackGraphql = jest.fn();
+
+    loadTopServiceSummaries.mockReturnValue(SERVICE_SUMMARIES);
+
+    const ctx = makeServerContext('/report');
+    initialProps = await HomeDialog.getInitialProps(ctx);
+  });
+
+  test('getInitialProps', () => {
+    expect(initialProps.stage).toEqual('home');
+    expect(initialProps.topServiceSummaries).toHaveLength(1);
+  });
+
+  test('rendering', () => {
+    const component = renderer.create(
+      <HomeDialog store={store} loopbackGraphql={loopbackGraphql} {...initialProps} />,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});
+
+describe('choose page', () => {
+  let initialProps: InitialProps;
+  let store;
+  let loopbackGraphql;
+
+  beforeEach(async () => {
+    store = new AppStore();
+    loopbackGraphql = jest.fn();
+
+    loadTopServiceSummaries.mockReturnValue(SERVICE_SUMMARIES);
+
+    const ctx = makeServerContext('/report', { stage: 'choose', description: 'Thanos is attacking' });
+    initialProps = await HomeDialog.getInitialProps(ctx);
+  });
+
+  test('getInitialProps', () => {
+    expect(initialProps.stage).toEqual('choose');
+    expect(initialProps.description).toEqual('Thanos is attacking');
+  });
+
+  test('rendering', () => {
+    const component = renderer.create(
+      <HomeDialog store={store} loopbackGraphql={loopbackGraphql} {...initialProps} />,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});
+
+
 describe('integration', () => {
   let wrapper;
   let store;
@@ -27,15 +95,11 @@ describe('integration', () => {
   let resolveSuggestions;
 
   beforeEach(() => {
-    // mock implementation always fires, but after a delay
-    debounce.mockImplementation((fn) => (...args) => Promise.resolve().then(fn.bind(null, ...args)));
-
     store = new AppStore();
-    store.topServiceSummaries = [];
 
     loadServiceSuggestions.mockReturnValue(new Promise((resolve) => { resolveSuggestions = resolve; }));
 
-    wrapper = mount(<HomeDialog store={store} loopbackGraphql={jest.fn()} stage="choose" />);
+    wrapper = mount(<HomeDialog store={store} description="Thanos is attacking" loopbackGraphql={jest.fn()} stage="choose" topServiceSummaries={[]} />);
   });
 
   afterEach(() => {
@@ -43,10 +107,9 @@ describe('integration', () => {
   });
 
   test('description and suggestions', async () => {
-    const descriptionWrapper = wrapper.find('textarea');
-    await descriptionWrapper.simulate('input', { target: { value: 'Thanos is attacking' } });
+    // get on the other side of the debounced lookup triggered by component will mount
+    await Promise.resolve();
 
-    expect(store.requestForm.description).toEqual('Thanos is attacking');
     expect(loadServiceSuggestions).toHaveBeenCalledWith(expect.anything(), 'Thanos is attacking');
 
     await resolveSuggestions(SERVICE_SUMMARIES);
@@ -55,6 +118,6 @@ describe('integration', () => {
     const serviceLink = wrapper.find('a').findWhere((el) => el.text() === 'Cosmic Incursion');
     expect(serviceLink.length).toEqual(1);
     // We look to the parent, which is a Next Link component.
-    expect(serviceLink.first().parent().props().href).toEqual('/report?code=CSMCINC');
+    expect(serviceLink.first().parent().props().href).toEqual('/report?code=CSMCINC&description=Thanos%20is%20attacking');
   });
 });

--- a/components/report/home/HomePane.js
+++ b/components/report/home/HomePane.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { css } from 'glamor';
 import Head from 'next/head';
 import Link from 'next/link';
-import Router from 'next/router';
 
 import type { ServiceSummary } from '../../../data/types';
 
@@ -37,16 +36,12 @@ const SERVICE_PICKER_STYLE = css({
 export type Props = {|
   description: string,
   handleDescriptionChanged: (ev: SyntheticInputEvent) => mixed,
+  nextFn: () => mixed,
   topServiceSummaries: ServiceSummary[],
 |}
 
-// Button handler rather than a link so we can disable it and because it
-// leads to a page that doesn't (currently?) accept GET requests.
-function handleNextClick() {
-  Router.push('/report?stage=choose', '/report');
-}
 
-export default function HomePane({ description, handleDescriptionChanged, topServiceSummaries }: Props) {
+export default function HomePane({ description, handleDescriptionChanged, nextFn, topServiceSummaries }: Props) {
   return (
     <div>
       <Head>
@@ -74,7 +69,7 @@ export default function HomePane({ description, handleDescriptionChanged, topSer
           />
 
           <div className="m-t500" style={{ textAlign: 'right' }}>
-            <button disabled={description.length === 0} className={`btn ${NEXT_BUTTON_STYLE.toString()}`} onClick={handleNextClick}>Start a Report</button>
+            <button disabled={description.length === 0} className={`btn ${NEXT_BUTTON_STYLE.toString()}`} onClick={nextFn}>Start a Report</button>
           </div>
         </div>
 

--- a/components/report/home/HomePane.stories.js
+++ b/components/report/home/HomePane.stories.js
@@ -51,6 +51,6 @@ const SERVICE_SUMMARIES = [
 storiesOf('HomePane', module)
   .add('Home', () => (
     <FormDialog>
-      <HomePane description="Dead raccoon on the sidewalk" topServiceSummaries={SERVICE_SUMMARIES} handleDescriptionChanged={action('Description changed')} />
+      <HomePane description="Dead raccoon on the sidewalk" topServiceSummaries={SERVICE_SUMMARIES} nextFn={action('Next')} handleDescriptionChanged={action('Description changed')} />
     </FormDialog>
   ));

--- a/components/report/home/HomePane.test.js
+++ b/components/report/home/HomePane.test.js
@@ -16,7 +16,7 @@ const SERVICE_SUMMARIES = [{
 describe('rendering', () => {
   test('existing description', () => {
     const component = renderer.create(
-      <HomePane description="Thanos is attacking" handleDescriptionChanged={jest.fn()} topServiceSummaries={SERVICE_SUMMARIES} />,
+      <HomePane description="Thanos is attacking" handleDescriptionChanged={jest.fn()} nextFn={jest.fn()} topServiceSummaries={SERVICE_SUMMARIES} />,
     );
 
     const json = component.toJSON();

--- a/components/report/home/__snapshots__/ChooseServicePane.test.js.snap
+++ b/components/report/home/__snapshots__/ChooseServicePane.test.js.snap
@@ -20,20 +20,11 @@ exports[`rendering loading 1`] = `
       </h2>
     </div>
     <div
-      className="m-v500"
+      className="m-v500 t--intro"
     >
-      <textarea
-        className={
-          Object {
-            "data-css-1i2zjxt": "",
-          }
-        }
-        defaultValue="Thanos is attacking"
-        name="description"
-        onBlur={[Function]}
-        onInput={[Function]}
-        placeholder="Tell us your problem"
-      />
+      “
+      Thanos is attacking
+      ”
     </div>
   </div>
   <div
@@ -73,20 +64,11 @@ exports[`rendering no description 1`] = `
       </h2>
     </div>
     <div
-      className="m-v500"
+      className="m-v500 t--intro"
     >
-      <textarea
-        className={
-          Object {
-            "data-css-139eqxv": "",
-          }
-        }
-        defaultValue=""
-        name="description"
-        onBlur={[Function]}
-        onInput={[Function]}
-        placeholder="Tell us your problem"
-      />
+      “
+      
+      ”
     </div>
   </div>
   <div
@@ -126,20 +108,11 @@ exports[`rendering no suggested summaries 1`] = `
       </h2>
     </div>
     <div
-      className="m-v500"
+      className="m-v500 t--intro"
     >
-      <textarea
-        className={
-          Object {
-            "data-css-1i2zjxt": "",
-          }
-        }
-        defaultValue="Thanos is attacking"
-        name="description"
-        onBlur={[Function]}
-        onInput={[Function]}
-        placeholder="Tell us your problem"
-      />
+      “
+      Thanos is attacking
+      ”
     </div>
   </div>
   <div
@@ -223,20 +196,11 @@ exports[`rendering some suggested summaries 1`] = `
       </h2>
     </div>
     <div
-      className="m-v500"
+      className="m-v500 t--intro"
     >
-      <textarea
-        className={
-          Object {
-            "data-css-1i2zjxt": "",
-          }
-        }
-        defaultValue="Thanos is attacking"
-        name="description"
-        onBlur={[Function]}
-        onInput={[Function]}
-        placeholder="Tell us your problem"
-      />
+      “
+      Thanos is attacking
+      ”
     </div>
   </div>
   <div

--- a/components/report/home/__snapshots__/HomeDialog.test.js.snap
+++ b/components/report/home/__snapshots__/HomeDialog.test.js.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`choose page rendering 1`] = `
+<div>
+  <div
+    className={
+      Object {
+        "data-css-1rld2am": "",
+      }
+    }
+  >
+    <div
+      className={
+        Object {
+          "data-css-1d2khtc": "",
+        }
+      }
+    >
+      <div
+        className=" br br-t400 br--y css-182uick"
+        style={
+          Object {
+            "maxWidth": 800,
+          }
+        }
+      >
+        <div>
+          <div
+            className="p-a300 p-a800--xl"
+            style={
+              Object {
+                "paddingBottom": ".75rem",
+              }
+            }
+          >
+            <div
+              className="sh sh--y"
+            >
+              <h2
+                className="sh-title"
+              >
+                File a Report
+              </h2>
+            </div>
+            <div
+              className="m-v500 t--intro"
+            >
+              “
+              Thanos is attacking
+              ”
+            </div>
+          </div>
+          <div
+            className="b b--g m-v500 p-a300 p-a800--xl"
+          >
+            <h3
+              className="stp"
+            >
+              How can we help?
+            </h3>
+            <div
+              className="t--info m-v300"
+            >
+              Matching your problem to BOS:311 services…
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`home page rendering 1`] = `
+<div>
+  <div
+    className={
+      Object {
+        "data-css-1rld2am": "",
+      }
+    }
+  >
+    <div
+      className={
+        Object {
+          "data-css-1d2khtc": "",
+        }
+      }
+    >
+      <div
+        className="p-a300 p-a800--xl br br-t400 br--y css-182uick"
+        style={Object {}}
+      >
+        <div>
+          <div
+            className="sh sh--y"
+          >
+            <h2
+              className="sh-title"
+            >
+              File a Report
+            </h2>
+          </div>
+          <div
+            className="t--intro m-v300"
+          >
+            Through BOS:311, you can report non-emergency issues with the City.
+          </div>
+          <div
+            className="g m-t500"
+          >
+            <div
+              className="g--7"
+            >
+              <h3
+                className="stp m-v100 css-17cwx2g"
+              >
+                Tell us your problem
+              </h3>
+              <textarea
+                className={
+                  Object {
+                    "data-css-1red1ju": "",
+                  }
+                }
+                defaultValue=""
+                name="description"
+                onBlur={[Function]}
+                onInput={[Function]}
+                placeholder="Example: my street hasn’t been plowed"
+              />
+              <div
+                className="m-t500"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="btn css-1q8b8td"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  Start a Report
+                </button>
+              </div>
+            </div>
+            <div
+              className="g--1"
+            />
+            <div
+              className="g--4 css-jnu3m1"
+            >
+              <div
+                className="m-v300 t--info"
+              >
+                You can also start a report by picking one of these popular services:
+              </div>
+              <ul
+                className="ul"
+              >
+                <li>
+                  <a
+                    className="t--sans tt-u"
+                    href="/report/CSMCINC"
+                    onClick={[Function]}
+                  >
+                    Cosmic Incursion
+                  </a>
+                </li>
+              </ul>
+              .
+              <div
+                className="t--info m-v300"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <a
+                  href="/services"
+                  onClick={[Function]}
+                >
+                  See all services…
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/report/map/LocationMap.stories.js
+++ b/components/report/map/LocationMap.stories.js
@@ -16,8 +16,8 @@ storiesOf('LocationMap', module)
     <div style={{ width: '100vw', height: '100vh' }}>{ story() }</div>
   ))
   .add('inactive', () => (
-    <LocationMap store={makeStore()} opacityRatio={0} mode="inactive" loopbackGraphql={(() => {}: any)} />
+    <LocationMap store={makeStore()} opacityRatio={0} mode="inactive" />
   ))
   .add('picker', () => (
-    <LocationMap store={makeStore()} opacityRatio={1} mode="picker" loopbackGraphql={(() => {}: any)} />
+    <LocationMap store={makeStore()} opacityRatio={1} mode="picker" />
   ));

--- a/components/report/request/ContactPane.stories.js
+++ b/components/report/request/ContactPane.stories.js
@@ -3,23 +3,22 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 
-import { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
 
 import ContactPane from './ContactPane';
 import FormDialog from '../../common/FormDialog';
 
-const makeStore = (fillIn: boolean) => {
-  const store = new AppStore();
-  const { contactInfo } = store.requestForm;
+const makeRequestForm = (fillIn: boolean) => {
+  const requestForm = new RequestForm();
 
   if (fillIn) {
-    contactInfo.firstName = 'Carol';
-    contactInfo.lastName = 'Danvers';
-    contactInfo.email = 'marvel@alphaflight.gov';
-    contactInfo.phone = '6175551234';
+    requestForm.firstName = 'Carol';
+    requestForm.lastName = 'Danvers';
+    requestForm.email = 'marvel@alphaflight.gov';
+    requestForm.phone = '6175551234';
   }
 
-  return store;
+  return requestForm;
 };
 
 storiesOf('ContactPane', module)
@@ -28,13 +27,15 @@ storiesOf('ContactPane', module)
 ))
 .add('Empty', () => (
   <ContactPane
-    store={makeStore(false)}
+    serviceName="Cosmic Incursion"
+    requestForm={makeRequestForm(false)}
     nextFunc={action('Next Step')}
   />
 ))
 .add('Filled Out', () => (
   <ContactPane
-    store={makeStore(true)}
+    serviceName="Cosmic Incursion"
+    requestForm={makeRequestForm(true)}
     nextFunc={action('Next Step')}
   />
 ));

--- a/components/report/request/ContactPane.test.js
+++ b/components/report/request/ContactPane.test.js
@@ -2,33 +2,31 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
 
 import ContactPane from './ContactPane';
 
-let store;
+let requestForm;
 
 beforeEach(() => {
-  store = new AppStore();
+  requestForm = new RequestForm();
 });
 
 test('blank request', () => {
   const component = renderer.create(
-    <ContactPane store={store} nextFunc={jest.fn()} />,
+    <ContactPane serviceName="Cosmic Incursion" requestForm={requestForm} nextFunc={jest.fn()} />,
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('filled request', () => {
-  const { contactInfo } = store.requestForm;
-
-  contactInfo.firstName = 'Carol';
-  contactInfo.lastName = 'Danvers';
-  contactInfo.email = 'marvel@alphaflight.gov';
-  contactInfo.phone = '6175551234';
+  requestForm.firstName = 'Carol';
+  requestForm.lastName = 'Danvers';
+  requestForm.email = 'marvel@alphaflight.gov';
+  requestForm.phone = '6175551234';
 
   const component = renderer.create(
-    <ContactPane store={store} nextFunc={jest.fn()} />,
+    <ContactPane serviceName="Cosmic Incursion" requestForm={requestForm} nextFunc={jest.fn()} />,
   );
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/components/report/request/LocationPopUp.stories.js
+++ b/components/report/request/LocationPopUp.stories.js
@@ -5,6 +5,7 @@ import { storiesOf, action } from '@kadira/storybook';
 import centered from '../../../storybook/centered';
 import LocationPopUp from './LocationPopUp';
 import { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
 
 const props = {
   nextFunc: action('Next'),
@@ -14,17 +15,15 @@ const props = {
 
 const makeStore = (address: string) => {
   const store = new AppStore();
-
-  store.requestForm.locationInfo.address = address;
-
+  store.mapLocation.address = address;
   return store;
 };
 
 storiesOf('LocationPopUp', module)
   .addDecorator(centered)
   .add('with address', () => (
-    <LocationPopUp {...props} store={makeStore('1 Franklin Park Rd\nBoston, MA 02121')} />
+    <LocationPopUp {...props} store={makeStore('1 Franklin Park Rd\nBoston, MA 02121')} requestForm={new RequestForm()} />
   ))
   .add('without address', () => (
-    <LocationPopUp {...props} store={makeStore('')} />
+    <LocationPopUp {...props} store={makeStore('')} requestForm={new RequestForm()} />
   ));

--- a/components/report/request/QuestionsPane.js
+++ b/components/report/request/QuestionsPane.js
@@ -13,9 +13,12 @@ import AttributeField from './AttributeField';
 import CloudinaryImageUpload from '../../../data/external/CloudinaryImageUpload';
 
 import type { AppStore } from '../../../data/store';
+import type RequestForm from '../../../data/store/RequestForm';
 
 export type Props = {|
   store: AppStore,
+  requestForm: RequestForm,
+  serviceName: string,
   nextFunc: () => mixed,
   nextIsSubmit: boolean,
 |};
@@ -57,16 +60,16 @@ export default class QuestionsPane extends React.Component {
 
   @action
   componentWillMount() {
-    const { store } = this.props;
+    const { store, requestForm } = this.props;
     this.imageUploader.config = store.apiKeys.cloudinary;
-    this.imageUploader.adoptedUrlObservable = extras.getAtom(store.requestForm, 'mediaUrl');
+    this.imageUploader.adoptedUrlObservable = extras.getAtom(requestForm, 'mediaUrl');
   }
 
   @action
   componentWillReceiveProps(newProps: Props) {
-    const { store } = newProps;
+    const { store, requestForm } = newProps;
     this.imageUploader.config = store.apiKeys.cloudinary;
-    this.imageUploader.adoptedUrlObservable = extras.getAtom(store.requestForm, 'mediaUrl');
+    this.imageUploader.adoptedUrlObservable = extras.getAtom(requestForm, 'mediaUrl');
   }
 
   @action
@@ -95,8 +98,8 @@ export default class QuestionsPane extends React.Component {
 
   @action.bound
   handleUpdateDescription(ev: SyntheticInputEvent) {
-    const { store } = this.props;
-    store.requestForm.description = ev.target.value;
+    const { requestForm } = this.props;
+    requestForm.description = ev.target.value;
   }
 
   setDropEl = (dropEl: ?Dropzone) => {
@@ -104,8 +107,8 @@ export default class QuestionsPane extends React.Component {
   }
 
   render() {
-    const { store, nextFunc, nextIsSubmit } = this.props;
-    const { currentService, requestForm: { description, questions, questionRequirementsMet } } = store;
+    const { requestForm, serviceName, nextFunc, nextIsSubmit } = this.props;
+    const { description, questions, questionRequirementsMet } = requestForm;
 
     const questionsEls = [];
     questions.forEach((q, i) => {
@@ -122,7 +125,7 @@ export default class QuestionsPane extends React.Component {
 
     return (
       <div>
-        <SectionHeader>{ currentService ? currentService.name : '' }</SectionHeader>
+        <SectionHeader>{ serviceName }</SectionHeader>
 
         <div className="g g--top">
           <div className="g--7 m-v500">

--- a/components/report/request/QuestionsPane.stories.js
+++ b/components/report/request/QuestionsPane.stories.js
@@ -3,17 +3,18 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 
+import type { Service } from '../../../data/types';
 import { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
 
 import { DEFAULT_SERVICE, SERVICE_WITH_METADATA } from './QuestionsPane.test';
 import QuestionsPane from './QuestionsPane';
 import FormDialog from '../../common/FormDialog';
 
-const makeStore = (service) => {
-  const store = new AppStore();
-  store.requestForm.description = 'I could use some heroic support.';
-  store.currentService = service;
-  return store;
+const makeRequestForm = (service: Service) => {
+  const requestForm = new RequestForm(service);
+  requestForm.description = 'I could use some heroic supporti';
+  return requestForm;
 };
 
 storiesOf('QuestionsPane', module)
@@ -22,14 +23,18 @@ storiesOf('QuestionsPane', module)
 ))
 .add('No Metadata', () => (
   <QuestionsPane
-    store={makeStore(DEFAULT_SERVICE)}
+    store={new AppStore()}
+    requestForm={makeRequestForm(DEFAULT_SERVICE)}
+    serviceName={'Cosmic Incursion'}
     nextFunc={action('Next Step')}
     nextIsSubmit
   />
 ))
 .add('With Metadata', () => (
   <QuestionsPane
-    store={makeStore(SERVICE_WITH_METADATA)}
+    store={new AppStore()}
+    requestForm={makeRequestForm(SERVICE_WITH_METADATA)}
+    serviceName={'Cosmic Incursion'}
     nextFunc={action('Next Step')}
     nextIsSubmit={false}
   />

--- a/components/report/request/QuestionsPane.test.js
+++ b/components/report/request/QuestionsPane.test.js
@@ -5,6 +5,7 @@ import renderer from 'react-test-renderer';
 
 import type { Service } from '../../../data/types';
 import { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
 
 import QuestionsPane from './QuestionsPane';
 
@@ -33,35 +34,36 @@ export const SERVICE_WITH_METADATA: Service = {
 };
 
 let store;
+let requestForm;
 
 beforeEach(() => {
   store = new AppStore();
-  store.currentService = DEFAULT_SERVICE;
+  requestForm = new RequestForm();
 });
 
 test('blank request', () => {
   const component = renderer.create(
-    <QuestionsPane store={store} nextFunc={jest.fn()} nextIsSubmit={false} />,
+    <QuestionsPane store={store} requestForm={requestForm} serviceName={DEFAULT_SERVICE.name} nextFunc={jest.fn()} nextIsSubmit={false} />,
   );
 
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('existing description', () => {
-  store.requestForm.description = 'Please pick up my bulk items. ';
+  requestForm.description = 'Please pick up my bulk items. ';
 
   const component = renderer.create(
-    <QuestionsPane store={store} nextFunc={jest.fn()} nextIsSubmit={false} />,
+    <QuestionsPane store={store} requestForm={requestForm} serviceName={DEFAULT_SERVICE.name} nextFunc={jest.fn()} nextIsSubmit={false} />,
   );
 
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('service with metadata', () => {
-  store.currentService = SERVICE_WITH_METADATA;
+  requestForm = new RequestForm(SERVICE_WITH_METADATA);
 
   const component = renderer.create(
-    <QuestionsPane store={store} nextFunc={jest.fn()} nextIsSubmit={false} />,
+    <QuestionsPane store={store} requestForm={requestForm} serviceName={SERVICE_WITH_METADATA.name} nextFunc={jest.fn()} nextIsSubmit={false} />,
   );
 
   expect(component.toJSON()).toMatchSnapshot();

--- a/components/report/request/RequestDialog.js
+++ b/components/report/request/RequestDialog.js
@@ -3,16 +3,22 @@
 import React from 'react';
 import Head from 'next/head';
 import { action, observable } from 'mobx';
-import ScopedError from 'react-scoped-error-component';
+// import ScopedError from 'react-scoped-error-component';
 import { observer } from 'mobx-react';
 import { fromPromise } from 'mobx-utils';
 import { css } from 'glamor';
+import type { Context } from 'next';
 import type { IPromiseBasedObservable } from 'mobx-utils';
 
-import type { SubmittedRequest } from '../../../data/types';
+import type { RequestAdditions } from '../../../server/next-handlers';
+
+import type { SubmittedRequest, Service } from '../../../data/types';
 import type { AppStore } from '../../../data/store';
+import RequestForm from '../../../data/store/RequestForm';
+import makeLoopbackGraphql from '../../../data/dao/loopback-graphql';
 import type { LoopbackGraphql } from '../../../data/dao/loopback-graphql';
 import submitRequest from '../../../data/dao/submit-request';
+import loadService from '../../../data/dao/load-service';
 
 import FormDialog from '../../common/FormDialog';
 import SectionHeader from '../../common/SectionHeader';
@@ -24,12 +30,18 @@ import LocationPopUp from './LocationPopUp';
 import ContactPane from './ContactPane';
 import SubmitPane from './SubmitPane';
 
-type Props = {|
-  store: AppStore,
+export type InitialProps = {|
   stage: 'questions' | 'location' | 'contact' | 'submit',
+  service: ?Service,
+  description: string,
+|}
+
+export type Props = {|
+  store: AppStore,
   loopbackGraphql: LoopbackGraphql,
   routeToServiceForm: (code: string, stage: string) => Promise<void>,
   setLocationMapActive: (active: boolean) => void,
+  /* :: ...InitialProps, */
 |}
 
 const COMMON_DIALOG_STYLE = {
@@ -48,10 +60,46 @@ const CORNER_DIALOG_STYLE = css(COMMON_DIALOG_STYLE, {
 export default class RequestDialog extends React.Component {
   props: Props;
 
+  requestForm: RequestForm;
   @observable requestSubmission: ?IPromiseBasedObservable<SubmittedRequest> = null;
 
+  // Called by ReportLayout
+  static async getInitialProps({ query, req, res }: Context<RequestAdditions>): Promise<InitialProps> {
+    const { code, description } = query;
+    let stage = query.stage;
+
+    const loopbackGraphql = makeLoopbackGraphql(req);
+
+    const service = await loadService(loopbackGraphql, code);
+
+    if (!service && res) {
+      res.statusCode = 404;
+    }
+
+    stage = stage || 'questions';
+
+    switch (stage) {
+      case 'questions':
+      case 'location':
+      case 'contact':
+      case 'submit':
+        return {
+          service,
+          stage,
+          description: description || '',
+        };
+      default:
+        throw new Error(`Unknown stage: ${stage}`);
+    }
+  }
+
+  @action
   componentWillMount() {
-    const { stage, setLocationMapActive } = this.props;
+    const { stage, description, setLocationMapActive, service } = this.props;
+
+    this.requestForm = new RequestForm(service);
+    this.requestForm.description = description;
+
     setLocationMapActive(stage === 'location');
   }
 
@@ -65,14 +113,14 @@ export default class RequestDialog extends React.Component {
   }
 
   makeNextAfterQuestions(): { fn: () => mixed, isSubmit: boolean } {
-    const { store: { requestForm } } = this.props;
+    const { requestForm } = this;
 
-    if (requestForm.locationInfo.ask) {
+    if (requestForm.showLocationPicker) {
       return {
         fn: this.routeToLocation,
         isSubmit: false,
       };
-    } else if (requestForm.contactInfo.ask) {
+    } else if (requestForm.showContactInfoForm) {
       return {
         fn: this.routeToContact,
         isSubmit: false,
@@ -86,9 +134,9 @@ export default class RequestDialog extends React.Component {
   }
 
   makeNextAfterLocation(): { fn: () => mixed, isSubmit: boolean } {
-    const { store: { requestForm } } = this.props;
+    const { requestForm } = this;
 
-    if (requestForm.contactInfo.ask) {
+    if (requestForm.showContactInfoForm) {
       return {
         fn: this.routeToContact,
         isSubmit: false,
@@ -102,48 +150,52 @@ export default class RequestDialog extends React.Component {
   }
 
   routeToLocation = () => {
-    const { store: { currentService }, routeToServiceForm } = this.props;
-    if (currentService) {
-      routeToServiceForm(currentService.code, 'location');
+    const { service, routeToServiceForm } = this.props;
+    if (service) {
+      routeToServiceForm(service.code, 'location');
     }
   }
 
   routeToContact = () => {
-    const { store: { currentService }, routeToServiceForm } = this.props;
-    if (currentService) {
-      routeToServiceForm(currentService.code, 'contact');
+    const { service, routeToServiceForm } = this.props;
+    if (service) {
+      routeToServiceForm(service.code, 'contact');
     }
   }
 
   @action.bound
   submitRequest(withContactInfo: boolean = false): Promise<mixed> {
-    const { store, loopbackGraphql, routeToServiceForm } = this.props;
-    const { currentService, requestForm } = store;
-    const { contactInfo, locationInfo, description, questions, mediaUrl } = requestForm;
+    const { requestForm } = this;
+    const { service, loopbackGraphql, routeToServiceForm } = this.props;
+    const { description, firstName, lastName, email, phone, location, address, questions, mediaUrl } = requestForm;
 
-    if (!currentService) {
-      throw new Error('currentService is null in submitRequest');
+    if (!service) {
+      throw new Error('service is null in submitRequest');
     }
 
     const promise = submitRequest(loopbackGraphql, {
-      service: currentService,
+      service,
       description,
       // We only send contact info with an affirmative boolean that's set by
       // the ContactPane form's submit button. That way contact info that was
       // loaded by localStorage won't be pushed to the server if the user didn't
       // see the contact info form or chose "submit without sending contact info"
-      contactInfo: withContactInfo ? contactInfo : null,
-      locationInfo,
+      firstName: withContactInfo ? firstName : null,
+      lastName: withContactInfo ? lastName : null,
+      email: withContactInfo ? email : null,
+      phone: withContactInfo ? phone : null,
+      location,
+      address,
       questions,
       mediaUrl,
     }).then((v) => {
-      store.resetRequest();
+      this.requestForm = new RequestForm(service);
       return v;
     });
 
     this.requestSubmission = fromPromise(promise);
 
-    routeToServiceForm(currentService.code, 'submit');
+    routeToServiceForm(service.code, 'submit');
 
     return promise;
   }
@@ -167,14 +219,14 @@ export default class RequestDialog extends React.Component {
 
   renderTitle() {
     const { requestSubmission } = this;
-    const { stage, store: { currentService } } = this.props;
+    const { stage, service } = this.props;
 
-    if (!currentService) {
+    if (!service) {
       return 'Not Found';
     }
 
     switch (stage) {
-      case 'questions': return currentService.name;
+      case 'questions': return service.name;
       case 'location': return 'Choose location';
       case 'contact': return 'Contact information';
       case 'submit':
@@ -194,36 +246,36 @@ export default class RequestDialog extends React.Component {
   }
 
   renderContent() {
-    const { requestSubmission } = this;
-    const { store, stage, loopbackGraphql } = this.props;
-    const { currentService, currentServiceError } = store;
+    const { requestSubmission, requestForm } = this;
+    const { store, stage, loopbackGraphql, service } = this.props;
 
-    if (!currentService) {
+    if (!service) {
       return <SectionHeader>Service not found</SectionHeader>;
     }
 
-    if (currentServiceError) {
-      return (
-        <div>
-          <SectionHeader>Error loading service</SectionHeader>
-          <ScopedError error={currentServiceError} />
-        </div>
-      );
-    }
+    // TODO(finh): Bring back service errors
+    // if (currentServiceError) {
+    //   return (
+    //     <div>
+    //       <SectionHeader>Error loading service</SectionHeader>
+    //       <ScopedError error={currentServiceError} />
+    //     </div>
+    //   );
+    // }
 
     switch (stage) {
       case 'questions': {
         const { fn, isSubmit } = this.makeNextAfterQuestions();
-        return <QuestionsPane store={store} nextFunc={fn} nextIsSubmit={isSubmit} />;
+        return <QuestionsPane store={store} requestForm={requestForm} serviceName={service.name} nextFunc={fn} nextIsSubmit={isSubmit} />;
       }
 
       case 'location': {
         const { fn, isSubmit } = this.makeNextAfterLocation();
-        return <LocationPopUp store={store} nextFunc={fn} nextIsSubmit={isSubmit} loopbackGraphql={loopbackGraphql} />;
+        return <LocationPopUp store={store} requestForm={requestForm} nextFunc={fn} nextIsSubmit={isSubmit} loopbackGraphql={loopbackGraphql} />;
       }
 
       case 'contact':
-        return <ContactPane store={store} nextFunc={this.submitRequest} />;
+        return <ContactPane requestForm={requestForm} serviceName={service.name} nextFunc={this.submitRequest} />;
 
       case 'submit':
         if (!requestSubmission) {

--- a/components/report/request/__snapshots__/ContactPane.test.js.snap
+++ b/components/report/request/__snapshots__/ContactPane.test.js.snap
@@ -9,7 +9,7 @@ exports[`blank request 1`] = `
       <h2
         className="sh-title"
       >
-        Contact Info
+        Cosmic Incursion
       </h2>
     </div>
     <p
@@ -204,7 +204,7 @@ exports[`filled request 1`] = `
       <h2
         className="sh-title"
       >
-        Contact Info
+        Cosmic Incursion
       </h2>
     </div>
     <p

--- a/data/dao/load-service.js
+++ b/data/dao/load-service.js
@@ -11,6 +11,6 @@ import LoadServiceGraphql from './graphql/LoadService.graphql';
 // required, &c.
 export default async function loadService(loopbackGraphql: LoopbackGraphql, code: string): Promise<?Service> {
   const queryVariables: LoadServiceQueryVariables = { code };
-  const response: LoadServiceQuery = await loopbackGraphql(LoadServiceGraphql, queryVariables);
+  const response: LoadServiceQuery = await loopbackGraphql(LoadServiceGraphql, queryVariables, { cacheKey: `loadService:${code}` });
   return response.service;
 }

--- a/data/dao/load-service.test.js
+++ b/data/dao/load-service.test.js
@@ -14,5 +14,5 @@ test('loadService', async () => {
     code: 'CSMCINC',
   };
 
-  expect(loopbackGraphql).toHaveBeenCalledWith(LoadServiceGraphql, queryVariables);
+  expect(loopbackGraphql).toHaveBeenCalledWith(LoadServiceGraphql, queryVariables, { cacheKey: 'loadService:CSMCINC' });
 });

--- a/data/dao/load-top-service-summaries.js
+++ b/data/dao/load-top-service-summaries.js
@@ -8,6 +8,6 @@ import LoadTopServiceSummariesGraphql from './graphql/LoadTopServiceSummaries.gr
 
 // Loads a list of all ServiceSummary objects available in the Open311 endpoint.
 export default async function loadTopServiceSummaries(loopbackGraphql: LoopbackGraphql): Promise<ServiceSummary[]> {
-  const response: LoadTopServiceSummariesQuery = await loopbackGraphql(LoadTopServiceSummariesGraphql);
+  const response: LoadTopServiceSummariesQuery = await loopbackGraphql(LoadTopServiceSummariesGraphql, null, { cacheKey: 'loadTopServiceSummaries' });
   return response.topServices;
 }

--- a/data/dao/load-top-service-summaries.test.js
+++ b/data/dao/load-top-service-summaries.test.js
@@ -7,5 +7,5 @@ import loadTopServiceSummaries from './load-top-service-summaries';
 test('loadTopServiceSummaries', async () => {
   const loopbackGraphql = jest.fn().mockReturnValue({});
   await loadTopServiceSummaries(loopbackGraphql);
-  expect(loopbackGraphql).toHaveBeenCalledWith(LoadTopServiceSummariesGraphql);
+  expect(loopbackGraphql).toHaveBeenCalledWith(LoadTopServiceSummariesGraphql, null, { cacheKey: 'loadTopServiceSummaries' });
 });

--- a/data/dao/submit-request.js
+++ b/data/dao/submit-request.js
@@ -2,7 +2,6 @@
 
 import type { Service, SubmittedRequest } from '../types';
 import type Question from '../store/Question';
-import type { ContactInfo, LocationInfo } from '../store/RequestForm';
 import type { LoopbackGraphql } from './loopback-graphql';
 import type { SubmitRequestMutationVariables, SubmitRequestMutation } from './graphql/types';
 import SubmitRequestGraphql from './graphql/SubmitRequest.graphql';
@@ -10,8 +9,12 @@ import SubmitRequestGraphql from './graphql/SubmitRequest.graphql';
 type Args = {|
   service: Service,
   description: string,
-  contactInfo: ?ContactInfo,
-  locationInfo: LocationInfo,
+  firstName: ?string,
+  lastName: ?string,
+  email: ?string,
+  phone: ?string,
+  location: ?{ lat: number, lng: number },
+  address: ?string,
   questions: Question[],
   mediaUrl: string,
 |};
@@ -24,8 +27,12 @@ export default async function submitRequest(loopbackGraphql: LoopbackGraphql, {
   service,
   description,
   mediaUrl,
-  contactInfo,
-  locationInfo,
+  firstName,
+  lastName,
+  email,
+  phone,
+  address,
+  location,
   questions,
 }: Args): Promise<SubmittedRequest> {
   const attributes = [];
@@ -48,12 +55,12 @@ export default async function submitRequest(loopbackGraphql: LoopbackGraphql, {
   const vars: SubmitRequestMutationVariables = {
     code: service.code,
     description,
-    firstName: contactInfo ? contactInfo.firstName : '',
-    lastName: contactInfo ? contactInfo.lastName : '',
-    email: contactInfo ? contactInfo.email : '',
-    phone: contactInfo ? contactInfo.phone : '',
-    location: locationInfo.location,
-    address: locationInfo.address,
+    firstName,
+    lastName,
+    email,
+    phone,
+    location,
+    address,
     mediaUrl,
     attributes,
   };

--- a/data/dao/submit-request.test.js
+++ b/data/dao/submit-request.test.js
@@ -4,7 +4,7 @@ import type { Service } from '../types';
 import type { SubmitRequestMutationVariables } from './graphql/types';
 import SubmitRequestGraphql from './graphql/SubmitRequest.graphql';
 
-import { AppStore } from '../store';
+import RequestForm from '../store/RequestForm';
 
 import submitRequest from './submit-request';
 
@@ -100,15 +100,11 @@ const COSMIC_SERVICE: Service = {
 };
 
 test('submitRequest', async () => {
-  // We use a store to build up questions and such for us.
-  const store = new AppStore();
-  store.currentService = COSMIC_SERVICE;
-
-  const requestForm = store.requestForm;
+  const requestForm = new RequestForm(COSMIC_SERVICE);
   requestForm.description = 'Things are bad';
-  requestForm.contactInfo.firstName = 'Carol';
-  requestForm.contactInfo.lastName = 'Danvers';
-  requestForm.contactInfo.email = 'marvel@alphaflight.gov';
+  requestForm.firstName = 'Carol';
+  requestForm.lastName = 'Danvers';
+  requestForm.email = 'marvel@alphaflight.gov';
 
   requestForm.questions[0].value = 'Thanos is here';
   requestForm.questions[2].value = 'us-avengers';
@@ -124,8 +120,12 @@ test('submitRequest', async () => {
   await submitRequest(loopbackGraphql, {
     service: COSMIC_SERVICE,
     description: requestForm.description,
-    contactInfo: requestForm.contactInfo,
-    locationInfo: requestForm.locationInfo,
+    firstName: requestForm.firstName,
+    lastName: requestForm.lastName,
+    email: requestForm.email,
+    phone: requestForm.phone,
+    location: requestForm.location,
+    address: requestForm.address,
     questions: requestForm.questions,
     mediaUrl: requestForm.mediaUrl,
   });

--- a/data/external/LocalStorageContactInfo.js
+++ b/data/external/LocalStorageContactInfo.js
@@ -1,0 +1,44 @@
+// @flow
+
+import { runInAction, observable, computed, autorunAsync } from 'mobx';
+import type RequestForm from '../store/RequestForm';
+
+export default class LocalStorageContactInfo {
+  @observable rememberInfo: boolean = false;
+
+  rememberInfoDisposer: Function;
+
+  constructor(requestForm: RequestForm) {
+    if (this.canRememberInfo) {
+      runInAction('LocalStorageContactInfo constructor', () => {
+        this.rememberInfo = localStorage.getItem('ContactInfo.firstName') != null;
+        requestForm.firstName = localStorage.getItem('ContactInfo.firstName') || '';
+        requestForm.lastName = localStorage.getItem('ContactInfo.lastName') || '';
+        requestForm.email = localStorage.getItem('ContactInfo.email') || '';
+        requestForm.phone = localStorage.getItem('ContactInfo.phone') || '';
+      });
+
+      autorunAsync('remember contact info', () => {
+        if (this.rememberInfo) {
+          localStorage.setItem('ContactInfo.firstName', requestForm.firstName);
+          localStorage.setItem('ContactInfo.lastName', requestForm.lastName);
+          localStorage.setItem('ContactInfo.email', requestForm.email);
+          localStorage.setItem('ContactInfo.phone', requestForm.phone);
+        } else {
+          localStorage.removeItem('ContactInfo.firstName');
+          localStorage.removeItem('ContactInfo.lastName');
+          localStorage.removeItem('ContactInfo.email');
+          localStorage.removeItem('ContactInfo.phone');
+        }
+      }, 250);
+    }
+  }
+
+  dispose() {
+    this.rememberInfoDisposer();
+  }
+
+  @computed get canRememberInfo(): boolean {
+    return typeof localStorage !== 'undefined';
+  }
+}

--- a/data/store/MapLocation.js
+++ b/data/store/MapLocation.js
@@ -1,0 +1,47 @@
+// @flow
+
+import { observable, reaction, runInAction } from 'mobx';
+
+import type { LoopbackGraphql } from '../dao/loopback-graphql';
+import reverseGeocode from '../dao/reverse-geocode';
+
+export default class MapLocation {
+  @observable location: ?{ lat: number, lng: number } = null;
+  @observable address: string = '';
+
+  reverseGeocodeDisposer: ?Function;
+
+  start(loopbackGraphql: LoopbackGraphql) {
+    this.reverseGeocodeDisposer = reaction(
+      () => this.location,
+      async (location) => {
+        if (!location || this.address) {
+          return;
+        }
+
+        const place = await reverseGeocode(loopbackGraphql, location);
+
+        runInAction('reverse geocode result', () => {
+          if (this.location && this.location.lat === location.lat && this.location.lng === location.lng) {
+            if (place) {
+              this.address = place.address;
+            } else {
+              this.address = '';
+            }
+          }
+        });
+      },
+      {
+        name: 'reverse geocoder',
+        fireImmediately: true,
+      },
+    );
+  }
+
+  stop() {
+    if (this.reverseGeocodeDisposer) {
+      this.reverseGeocodeDisposer();
+      this.reverseGeocodeDisposer = null;
+    }
+  }
+}

--- a/data/store/MapLocation.test.js
+++ b/data/store/MapLocation.test.js
@@ -1,0 +1,58 @@
+// @flow
+
+import type { ReverseGeocodedPlace } from '../types';
+import MapLocation from './MapLocation';
+
+jest.mock('../dao/reverse-geocode');
+const reverseGeocode: JestMockFn = (require('../dao/reverse-geocode'): any).default;
+
+describe('reverse geocoding', () => {
+  let mapLocation;
+  let loopbackGraphql;
+  let resolveGraphql: (place: ?ReverseGeocodedPlace) => void;
+
+  beforeEach(() => {
+    reverseGeocode.mockReturnValue(new Promise((resolve) => {
+      resolveGraphql = resolve;
+    }));
+
+    loopbackGraphql = jest.fn();
+
+    mapLocation = new MapLocation();
+    mapLocation.start(loopbackGraphql);
+  });
+
+  afterEach(() => {
+    mapLocation.stop();
+  });
+
+  it('reverse geocodes when the location changes', async () => {
+    mapLocation.location = {
+      lat: 42.36035940296916,
+      lng: -71.05802536010744,
+    };
+
+    // before reverse geocode happens
+    expect(mapLocation.address).toEqual('');
+
+    expect(reverseGeocode).toHaveBeenCalledWith(loopbackGraphql, {
+      lat: 42.36035940296916,
+      lng: -71.05802536010744,
+    });
+
+    await resolveGraphql({
+      address: '1 City Hall Plaza',
+      location: {
+        lat: 42.36035940296916,
+        lng: -71.05802536010744,
+      },
+    });
+
+    // after reverse geocode
+    expect(mapLocation.location).toEqual({
+      lat: 42.36035940296916,
+      lng: -71.05802536010744,
+    });
+    expect(mapLocation.address).toEqual('1 City Hall Plaza');
+  });
+});

--- a/data/store/RequestForm.js
+++ b/data/store/RequestForm.js
@@ -1,95 +1,68 @@
 // @flow
 
-import { observable, computed, action, autorunAsync } from 'mobx';
+import { observable, computed } from 'mobx';
 
 import type { Service } from '../types';
 import Question from './Question';
 
-export class ContactInfo {
-  @observable ask: boolean = true;
-  @observable required: boolean = false;
+// Class to encapsulate the request that's being built up over the course of
+// the web flow.
+export default class RequestForm {
+  _service: ?Service;
+
+  @computed get code(): string {
+    return this._service ? this._service.code : '';
+  }
+
+  @observable description: string = '';
+  @observable mediaUrl: string = ''
+
+  @observable address: string = '';
+  @observable.shallow location: ?{ lat: number, lng: number } = null;
+
   @observable firstName: string = '';
   @observable lastName: string = '';
   @observable email: string = '';
   @observable phone: string = '';
 
-  @observable rememberInfo: boolean = false;
+  @observable questions: Question[] = [];
 
-  constructor() {
-    if (this.canRememberInfo) {
-      this.rememberInfo = localStorage.getItem('ContactInfo.firstName') != null;
-      this.firstName = localStorage.getItem('ContactInfo.firstName') || '';
-      this.lastName = localStorage.getItem('ContactInfo.lastName') || '';
-      this.email = localStorage.getItem('ContactInfo.email') || '';
-      this.phone = localStorage.getItem('ContactInfo.phone') || '';
+  @computed get showContactInfoForm(): boolean {
+    return !!this._service && this._service.contactRequirement !== 'HIDDEN';
+  }
 
-      autorunAsync('remember contact info', () => {
-        if (this.rememberInfo) {
-          localStorage.setItem('ContactInfo.firstName', this.firstName);
-          localStorage.setItem('ContactInfo.lastName', this.lastName);
-          localStorage.setItem('ContactInfo.email', this.email);
-          localStorage.setItem('ContactInfo.phone', this.phone);
-        } else {
-          localStorage.removeItem('ContactInfo.firstName');
-          localStorage.removeItem('ContactInfo.lastName');
-          localStorage.removeItem('ContactInfo.email');
-          localStorage.removeItem('ContactInfo.phone');
-        }
-      }, 250);
-    }
+  @computed get contactInfoRequired(): boolean {
+    return !!this._service && this._service.contactRequirement === 'REQUIRED';
   }
 
   // can be false even when required is false to differentiate between submitting
   // and skipping
-  @computed
-  get requirementsMet(): boolean {
+  @computed get contactInfoRequirementsMet(): boolean {
     return !!(this.firstName && this.lastName && this.email);
   }
 
-  @computed get canRememberInfo(): boolean {
-    return typeof localStorage !== 'undefined';
+  @computed get showLocationPicker(): boolean {
+    return !!this._service && this._service.locationRequirement !== 'HIDDEN';
   }
-}
 
-export class LocationInfo {
-  @observable ask: boolean = true;
-  @observable required: boolean = false;
-  @observable address: string = '';
-  @observable.shallow location: ?{ lat: number, lng: number } = null;
+  @computed get locationRequired(): boolean {
+    return !!this._service && this._service.locationRequirement === 'REQUIRED';
+  }
 
-  // can be false even when required is false to differentiate between submitting
-  // and skipping
-  @computed get requirementsMet(): boolean {
+  @computed get locationRequirementsMet(): boolean {
     return this.address.length > 0;
-  }
-}
-
-// Class to encapsulate the request that's being built up over the course of
-// the web flow.
-export default class RequestForm {
-  @observable description: string = '';
-  @observable mediaUrl: string = ''
-
-  @observable contactInfo: ContactInfo = new ContactInfo();
-  @observable locationInfo: LocationInfo = new LocationInfo();
-  @observable questions: Question[] = [];
-
-  @action
-  updateForService(service: ?Service) {
-    this.questions = [];
-
-    if (service) {
-      this.contactInfo.required = service.contactRequirement === 'REQUIRED';
-      this.contactInfo.ask = service.contactRequirement !== 'HIDDEN';
-
-      this.locationInfo.required = service.locationRequirement === 'REQUIRED';
-      this.contactInfo.ask = service.contactRequirement !== 'HIDDEN';
-
-      this.questions = Question.buildQuestions(service.attributes);
-    }
   }
 
   @computed get questionRequirementsMet(): boolean {
     return this.questions.filter((q) => !q.required || !q.visible || q.requirementsMet).length === this.questions.length;
+  }
+
+  constructor(service: ?Service) {
+    this._service = service;
+    if (service) {
+      this.questions = Question.buildQuestions(service.attributes);
+    } else {
+      this.questions = [];
+    }
   }
 }

--- a/data/store/RequestForm.test.js
+++ b/data/store/RequestForm.test.js
@@ -99,21 +99,19 @@ describe('questionRequirementsMet', () => {
   let requestForm;
 
   beforeEach(() => {
-    requestForm = new RequestForm();
+    requestForm = new RequestForm(COSMIC_SERVICE);
   });
 
   it('is true when there are no questions', () => {
+    requestForm = new RequestForm();
     expect(requestForm.questionRequirementsMet).toEqual(true);
   });
 
   it('is false if required questions don’t have values', () => {
-    requestForm.updateForService(COSMIC_SERVICE);
     expect(requestForm.questionRequirementsMet).toEqual(false);
   });
 
   it('is true if required questions have valid values', () => {
-    requestForm.updateForService(COSMIC_SERVICE);
-
     const avengersQuestion = requestForm.questions.find(({ code }) => code === 'SR-AVENG');
     if (!avengersQuestion) {
       throw new Error('missing');
@@ -125,8 +123,6 @@ describe('questionRequirementsMet', () => {
   });
 
   it('is false if required questions have invalid values', () => {
-    requestForm.updateForService(COSMIC_SERVICE);
-
     const avengersQuestion = requestForm.questions.find(({ code }) => code === 'SR-AVENG');
     if (!avengersQuestion) {
       throw new Error('missing');
@@ -138,8 +134,6 @@ describe('questionRequirementsMet', () => {
   });
 
   test('visibility of required question', () => {
-    requestForm.updateForService(COSMIC_SERVICE);
-
     const avengersQuestion = requestForm.questions.find(({ code }) => code === 'SR-AVENG');
     if (!avengersQuestion) {
       throw new Error('missing');

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -2,12 +2,10 @@
 /* global window */
 /* eslint no-underscore-dangle: 0 */
 
-import { observable, computed, useStrict, action } from 'mobx';
+import { observable, useStrict, action } from 'mobx';
 
-import type { Service, ServiceSummary } from '../types';
-
-import RequestForm from './RequestForm';
 import RequestSearch from './RequestSearch';
+import MapLocation from './MapLocation';
 import Ui from './Ui';
 import BrowserLocation from './BrowserLocation';
 import AllServices from './AllServices';
@@ -16,19 +14,16 @@ import AllServices from './AllServices';
 useStrict(true);
 
 export class AppStore {
-  @observable requestForm: RequestForm = new RequestForm();
+  // Initialization data from the server
+  apiKeys: {[service: string]: any} = {};
+
   requestSearch: RequestSearch = new RequestSearch();
   ui: Ui = new Ui();
   browserLocation: BrowserLocation = new BrowserLocation();
+  mapLocation: MapLocation = new MapLocation();
   allServices: AllServices = new AllServices();
 
-  @observable.shallow topServiceSummaries: ServiceSummary[];
-  serviceCache: Map<string, Service> = observable.shallowMap({});
-
   @observable liveAgentAvailable: boolean = (typeof window !== 'undefined' && window.LIVE_AGENT_AVAILABLE) || false;
-
-  // Initialization data from the server
-  apiKeys: {[service: string]: any} = {};
 
   _liveAgentButtonId: string = '';
 
@@ -63,34 +58,6 @@ export class AppStore {
       case 'BUTTON_UNAVAILABLE': this.liveAgentAvailable = false; break;
       default: break;
     }
-  }
-
-  @observable.ref _currentService: ?Service = null;
-  @observable.ref currentServiceError: ?Object = null;
-
-  @computed get currentService(): ?Service {
-    return this._currentService;
-  }
-
-  set currentService(service: ?Service) {
-    if (service === this._currentService) {
-      return;
-    }
-
-    this._currentService = service;
-    this.currentServiceError = null;
-
-    try {
-      this.requestForm.updateForService(service);
-    } catch (e) {
-      this.currentServiceError = e;
-    }
-  }
-
-  @action
-  // Call after a succesful submit to clear the form
-  resetRequest() {
-    this.requestForm = new RequestForm();
   }
 }
 

--- a/lib/mixins/with-store.js
+++ b/lib/mixins/with-store.js
@@ -8,6 +8,7 @@ import { runInAction } from 'mobx';
 
 import type { RequestAdditions } from '../../server/next-handlers';
 
+import { setClientCache } from '../../data/dao/loopback-graphql';
 import getStore from '../../data/store';
 import type { AppStore } from '../../data/store';
 
@@ -30,9 +31,16 @@ export default <OP, P: $Subtype<Object>, S> (Component: Class<React.Component<OP
       liveAgentButtonId: req.liveAgentButtonId,
     } : null;
 
+    const loopbackGraphqlCache = req ? req.loopbackGraphqlCache : null;
+
+    // TODO(finh): If we really needed to, we could try and find the cached
+    // graphQL values in the initialProps and replace them with cache keys, and
+    // then do a lookup into the cache ond the other side in render().
+
     return {
       ...initialProps,
       initialStoreState,
+      loopbackGraphqlCache,
     };
   }
 
@@ -45,6 +53,10 @@ export default <OP, P: $Subtype<Object>, S> (Component: Class<React.Component<OP
       runInAction('withStore initialization', () => {
         Object.assign(this.store, props.initialStoreState);
       });
+    }
+
+    if (props.loopbackGraphqlCache) {
+      setClientCache(props.loopbackGraphqlCache);
     }
   }
 

--- a/server/next-handlers.js
+++ b/server/next-handlers.js
@@ -20,6 +20,7 @@ export type RequestAdditions = {|
     mapbox: Object,
   |},
   liveAgentButtonId: string,
+  loopbackGraphqlCache: {[key: string]: mixed},
 |}
 
 const nextHandler = (app, page, staticQuery) => async ({ method, server, raw: { req, res }, query, params }, reply) => {
@@ -36,6 +37,7 @@ const nextHandler = (app, page, staticQuery) => async ({ method, server, raw: { 
       },
     },
     liveAgentButtonId: process.env.LIVE_AGENT_BUTTON_ID || '',
+    loopbackGraphqlCache: {},
   };
 
   Object.assign(req, requestAdditions);


### PR DESCRIPTION
Adds an explicit cache at the loopbackGraphql layer that is initialized
with server-side requests. Removes akward store-population from
ReportLayout and store reading from getInitialProps.

Moves RequestForm to be localized at the RequestDialog component so that
its lifetime naturally matches that component. Pushes more things around
as props rather than hanging off of the store so that dependencies are
more obvious.