### PR TITLE
Shows the translate dialog automatically

### DIFF
--- a/components/report/ReportLayout.js
+++ b/components/report/ReportLayout.js
@@ -90,7 +90,7 @@ export default class ReportLayout extends React.Component {
 
     let data;
 
-    if (query.translate) {
+    if (query.translate === '1') {
       data = {
         view: 'translate',
         props: {},
@@ -195,7 +195,7 @@ export default class ReportLayout extends React.Component {
             />}
 
           { data.view === 'translate' &&
-            <TranslateDialog />
+            <TranslateDialog languages={store.languages} />
           }
         </div>
 

--- a/components/report/__snapshots__/ReportLayout.test.js.snap
+++ b/components/report/__snapshots__/ReportLayout.test.js.snap
@@ -917,7 +917,7 @@ exports[`existing service page rendering phone location step 1`] = `
     <div
       className={
         Object {
-          "data-css-1xznh3v": "",
+          "data-css-5ju6dk": "",
         }
       }
     >
@@ -1222,209 +1222,199 @@ exports[`report form rendering 1`] = `
         }
       />
     </div>
-    <div>
-      <div
-        className={
-          Object {
-            "data-css-1rld2am": "",
-          }
+    <div
+      className={
+        Object {
+          "data-css-1d2khtc": "",
         }
+      }
+    >
+      <div
+        className=" br br-t400 br--y css-182uick"
+        style={Object {}}
       >
-        <div
-          className={
-            Object {
-              "data-css-1d2khtc": "",
-            }
-          }
-        >
+        <div>
           <div
-            className=" br br-t400 br--y css-182uick"
-            style={Object {}}
+            className="p-a300 p-a800--xl"
           >
-            <div>
-              <div
-                className="p-a300 p-a800--xl"
+            <div
+              className="sh sh--y"
+            >
+              <h1
+                className="sh-title"
               >
-                <div
-                  className="sh sh--y"
-                >
-                  <h1
-                    className="sh-title"
+                BOS:311 — File a Report
+              </h1>
+            </div>
+            <div
+              className="t--info m-v300"
+            >
+              Through BOS:311, you can report non-emergency issues with the City.
+            </div>
+            <div
+              className="g m-t500"
+            >
+              <div
+                className="g--7 css-1vm2aiv"
+              >
+                <div>
+                  <h2
+                    className="stp m-v100"
                   >
-                    BOS:311 — File a Report
-                  </h1>
-                </div>
-                <div
-                  className="t--info m-v300"
-                >
-                  Through BOS:311, you can report non-emergency issues with the City.
-                </div>
-                <div
-                  className="g m-t500"
-                >
-                  <div
-                    className="g--7 css-1vm2aiv"
-                  >
-                    <div>
-                      <h2
-                        className="stp m-v100"
-                      >
-                        Tell us your problem:
-                      </h2>
-                      <textarea
-                        aria-label="Description of the problem"
-                        className={
-                          Object {
-                            "data-css-14mt46e": "",
-                          }
-                        }
-                        defaultValue=""
-                        name="description"
-                        onBlur={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        placeholder=""
-                      />
-                    </div>
-                    <div
-                      className="m-t500"
-                      style={
-                        Object {
-                          "textAlign": "right",
-                        }
+                    Tell us your problem:
+                  </h2>
+                  <textarea
+                    aria-label="Description of the problem"
+                    className={
+                      Object {
+                        "data-css-14mt46e": "",
                       }
-                    >
-                      <button
-                        className="btn m-h100"
-                        onClick={[Function]}
-                      >
-                        Start Live Chat
-                      </button>
-                      <button
-                        className="btn css-1q8b8td"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        Start a Report
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    className="g--1 m-v300 css-1sliefw"
+                    }
+                    defaultValue=""
+                    name="description"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    placeholder=""
+                  />
+                </div>
+                <div
+                  className="m-t500"
+                  style={
+                    Object {
+                      "textAlign": "right",
+                    }
+                  }
+                >
+                  <button
+                    className="btn m-h100"
+                    onClick={[Function]}
                   >
-                    <div
-                      className="br br-a150 css-7mg7kt"
-                    />
-                    <div
-                      className="br br-a150 t--info css-u5arvv"
-                    >
-                      or
-                    </div>
-                    <div
-                      className="br br-a150 css-7mg7kt"
-                    />
-                  </div>
-                  <div
-                    className="g--4"
+                    Start Live Chat
+                  </button>
+                  <button
+                    className="btn css-1q8b8td"
+                    disabled={true}
+                    onClick={[Function]}
                   >
-                    <h2
-                      className="a11y--h"
-                    >
-                      Popular Services
-                    </h2>
-                    <div
-                      className="t--info"
-                    >
-                      You can also start a report by picking one of these popular services:
-                    </div>
-                    <ul
-                      className="ul m-v300"
-                    >
-                      <li
-                        className="t--info"
-                      >
-                        <a
-                          className="m-v100"
-                          href="/report/CSMCINC"
-                          onClick={[Function]}
-                        >
-                          Cosmic Incursion
-                        </a>
-                      </li>
-                    </ul>
-                    <div
-                      className="t--info"
-                    >
-                      <a
-                        href="/services"
-                        onClick={[Function]}
-                      >
-                        See all services…
-                      </a>
-                    </div>
-                  </div>
+                    Start a Report
+                  </button>
                 </div>
               </div>
               <div
-                className="b b--g p-a300 p-a800--xl css-17cwx2g"
-                role="search"
-                style={
-                  Object {
-                    "paddingBottom": 0,
-                    "paddingTop": 0,
-                  }
-                }
+                className="g--1 m-v300 css-1sliefw"
+              >
+                <div
+                  className="br br-a150 css-7mg7kt"
+                />
+                <div
+                  className="br br-a150 t--info css-u5arvv"
+                >
+                  or
+                </div>
+                <div
+                  className="br br-a150 css-7mg7kt"
+                />
+              </div>
+              <div
+                className="g--4"
               >
                 <h2
                   className="a11y--h"
                 >
-                  Public Reports
+                  Popular Services
                 </h2>
                 <div
-                  className="g"
+                  className="t--info"
                 >
-                  <form
-                    acceptCharset="UTF-8"
-                    action="/lookup"
-                    className="sf sf--y sf--md g--7 m-v400"
-                    method="get"
-                    onSubmit={[Function]}
-                  >
-                    <div
-                      className="sf-i"
-                    >
-                      <input
-                        aria-label="Search field"
-                        className="sf-i-f"
-                        name="q"
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="Search by case ID or keywords…"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        className="sf-i-b"
-                        type="submit"
-                      >
-                        Search
-                      </button>
-                    </div>
-                  </form>
-                  <div
-                    className="g--1"
-                  />
-                  <div
-                    className="g--4 t--info css-12alag6"
+                  You can also start a report by picking one of these popular services:
+                </div>
+                <ul
+                  className="ul m-v300"
+                >
+                  <li
+                    className="t--info"
                   >
                     <a
-                      href="/search"
+                      className="m-v100"
+                      href="/report/CSMCINC"
                       onClick={[Function]}
                     >
-                      Browse public cases
+                      Cosmic Incursion
                     </a>
-                  </div>
+                  </li>
+                </ul>
+                <div
+                  className="t--info"
+                >
+                  <a
+                    href="/services"
+                    onClick={[Function]}
+                  >
+                    See all services…
+                  </a>
                 </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="b b--g p-a300 p-a800--xl css-17cwx2g"
+            role="search"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <h2
+              className="a11y--h"
+            >
+              Public Reports
+            </h2>
+            <div
+              className="g"
+            >
+              <form
+                acceptCharset="UTF-8"
+                action="/lookup"
+                className="sf sf--y sf--md g--7 m-v400"
+                method="get"
+                onSubmit={[Function]}
+              >
+                <div
+                  className="sf-i"
+                >
+                  <input
+                    aria-label="Search field"
+                    className="sf-i-f"
+                    name="q"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search by case ID or keywords…"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="sf-i-b"
+                    type="submit"
+                  >
+                    Search
+                  </button>
+                </div>
+              </form>
+              <div
+                className="g--1"
+              />
+              <div
+                className="g--4 t--info css-12alag6"
+              >
+                <a
+                  href="/search"
+                  onClick={[Function]}
+                >
+                  Browse public cases
+                </a>
               </div>
             </div>
           </div>
@@ -1540,87 +1530,95 @@ exports[`translate page rendering 1`] = `
       />
     </div>
     <div
-      className="p-a300 p-a800--xl br br-t400 br--y css-182uick"
-      style={Object {}}
+      className={
+        Object {
+          "data-css-1d2khtc": "",
+        }
+      }
     >
       <div
-        className={
-          Object {
-            "data-css-4u7o5n": "",
-          }
-        }
+        className="p-a300 p-a800--xl br br-t400 br--y css-182uick"
+        style={Object {}}
       >
         <div
-          className="g"
-        >
-          <button
-            className="btn g--2 m-v100 "
-            onClick={[Function]}
-          >
-            Kreyòl Ayisyen
-          </button>
-          <button
-            className="btn g--2 m-v100 "
-            onClick={[Function]}
-          >
-            Português
-          </button>
-          <button
-            className="btn g--2 m-v100 btn--c"
-            onClick={[Function]}
-          >
-            Español
-          </button>
-          <button
-            className="btn g--2 m-v100 "
-            onClick={[Function]}
-          >
-            Tiếng Việt
-          </button>
-          <button
-            className="btn g--2 m-v100 "
-            onClick={[Function]}
-          >
-            简体中文
-          </button>
-          <button
-            className="btn g--2 m-v100 "
-            onClick={[Function]}
-          >
-            繁體中文
-          </button>
-        </div>
-        <div
-          className="g m-v500 p-a500"
-          style={
+          className={
             Object {
-              "alignItems": "center",
+              "data-css-1lvs59o": "",
             }
           }
         >
           <div
-            className="g--1"
-          />
-          <div
-            className="g--2"
+            className="g"
           >
-            <div
-              className={
-                Object {
-                  "data-css-1y4p5hu": "",
-                }
-              }
-            />
+            <button
+              className="btn g--2 m-v100 "
+              onClick={[Function]}
+            >
+              Kreyòl Ayisyen
+            </button>
+            <button
+              className="btn g--2 m-v100 "
+              onClick={[Function]}
+            >
+              Português
+            </button>
+            <button
+              className="btn g--2 m-v100 btn--c"
+              onClick={[Function]}
+            >
+              Español
+            </button>
+            <button
+              className="btn g--2 m-v100 "
+              onClick={[Function]}
+            >
+              Tiếng Việt
+            </button>
+            <button
+              className="btn g--2 m-v100 "
+              onClick={[Function]}
+            >
+              简体中文
+            </button>
+            <button
+              className="btn g--2 m-v100 "
+              onClick={[Function]}
+            >
+              繁體中文
+            </button>
           </div>
           <div
-            className="g--8 t--intro"
+            className="g m-v500 p-a500"
             style={
               Object {
-                "fontStyle": "normal",
+                "alignItems": "center",
               }
             }
           >
-            If you need to report a non-emergency issue with the City of Boston, please call BOS:311 at 311 or 617-635-4500.
+            <div
+              className="g--1"
+            />
+            <div
+              className="g--2"
+            >
+              <div
+                className={
+                  Object {
+                    "data-css-1y4p5hu": "",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="g--8 t--intro"
+              style={
+                Object {
+                  "fontStyle": "normal",
+                }
+              }
+            >
+              If you need to report a non-emergency issue with the City of Boston, please call BOS:311 at 311 or 617-635-4500.
+            </div>
           </div>
         </div>
       </div>

--- a/components/report/home/HomeDialog.test.js
+++ b/components/report/home/HomeDialog.test.js
@@ -100,7 +100,7 @@ describe('integration', () => {
 
     loadServiceSuggestions.mockReturnValue(new Promise((resolve) => { resolveSuggestions = resolve; }));
 
-    wrapper = mount(<HomeDialog store={store} description="Thanos is attacking" loopbackGraphql={jest.fn()} stage="choose" topServiceSummaries={[]} />);
+    wrapper = mount(<HomeDialog store={store} description="Thanos is attacking" loopbackGraphql={jest.fn()} stage="choose" topServiceSummaries={[]} bypassTranslateDialog />);
   });
 
   afterEach(() => {

--- a/components/report/home/__snapshots__/HomeDialog.test.js.snap
+++ b/components/report/home/__snapshots__/HomeDialog.test.js.snap
@@ -1,148 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`choose page rendering 1`] = `
-<div>
+<div
+  className={
+    Object {
+      "data-css-1d2khtc": "",
+    }
+  }
+>
   <div
-    className={
+    className=" br br-t400 br--y css-182uick"
+    style={
       Object {
-        "data-css-1rld2am": "",
+        "maxWidth": 800,
       }
     }
   >
-    <div
-      className={
-        Object {
-          "data-css-1d2khtc": "",
-        }
-      }
-    >
+    <div>
       <div
-        className=" br br-t400 br--y css-182uick"
+        className="p-a300 p-a800--xl"
         style={
           Object {
-            "maxWidth": 800,
+            "paddingBottom": ".75rem",
           }
         }
       >
+        <div
+          className="sh sh--y"
+        >
+          <h1
+            className="sh-title"
+          >
+            BOS:311 — File a Report
+          </h1>
+        </div>
+        <div
+          className="m-v500 t--intro"
+        >
+          “
+          Thanos is attacking
+          ”
+        </div>
+      </div>
+      <div
+        className="b b--g p-a300 p-a800--xl"
+      >
+        <h2
+          className="stp"
+        >
+          How can we help?
+        </h2>
         <div>
           <div
-            className="p-a300 p-a800--xl"
-            style={
-              Object {
-                "paddingBottom": ".75rem",
-              }
-            }
+            className="t--info m-v300"
           >
-            <div
-              className="sh sh--y"
-            >
-              <h1
-                className="sh-title"
-              >
-                BOS:311 — File a Report
-              </h1>
-            </div>
-            <div
-              className="m-v500 t--intro"
-            >
-              “
-              Thanos is attacking
-              ”
-            </div>
+            Matching your problem to BOS:311 services…
           </div>
           <div
-            className="b b--g p-a300 p-a800--xl"
+            className="p-a300 g css-rdsogp"
           >
-            <h2
-              className="stp"
+            <div
+              className="g--4 css-19eoixt"
             >
-              How can we help?
-            </h2>
-            <div>
-              <div
-                className="t--info m-v300"
+              <span
+                className={
+                  Object {
+                    "data-css-17mox4x": "",
+                  }
+                }
               >
-                Matching your problem to BOS:311 services…
-              </div>
-              <div
-                className="p-a300 g css-rdsogp"
+                <svg
+                  className={
+                    Object {
+                      "data-css-1acy7qc": "",
+                    }
+                  }
+                  role="img"
+                >
+                  <use
+                    height="100%"
+                    xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              className="g--4 css-19eoixt"
+            >
+              <span
+                className={
+                  Object {
+                    "data-css-17mox4x": "",
+                  }
+                }
               >
-                <div
-                  className="g--4 css-19eoixt"
-                >
-                  <span
-                    className={
-                      Object {
-                        "data-css-17mox4x": "",
-                      }
+                <svg
+                  className={
+                    Object {
+                      "data-css-1acy7qc": "",
                     }
-                  >
-                    <svg
-                      className={
-                        Object {
-                          "data-css-1acy7qc": "",
-                        }
-                      }
-                      role="img"
-                    >
-                      <use
-                        height="100%"
-                        xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
-                      />
-                    </svg>
-                  </span>
-                </div>
-                <div
-                  className="g--4 css-19eoixt"
+                  }
+                  role="img"
                 >
-                  <span
-                    className={
-                      Object {
-                        "data-css-17mox4x": "",
-                      }
+                  <use
+                    height="100%"
+                    xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              className="g--4 css-19eoixt"
+            >
+              <span
+                className={
+                  Object {
+                    "data-css-17mox4x": "",
+                  }
+                }
+              >
+                <svg
+                  className={
+                    Object {
+                      "data-css-1acy7qc": "",
                     }
-                  >
-                    <svg
-                      className={
-                        Object {
-                          "data-css-1acy7qc": "",
-                        }
-                      }
-                      role="img"
-                    >
-                      <use
-                        height="100%"
-                        xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
-                      />
-                    </svg>
-                  </span>
-                </div>
-                <div
-                  className="g--4 css-19eoixt"
+                  }
+                  role="img"
                 >
-                  <span
-                    className={
-                      Object {
-                        "data-css-17mox4x": "",
-                      }
-                    }
-                  >
-                    <svg
-                      className={
-                        Object {
-                          "data-css-1acy7qc": "",
-                        }
-                      }
-                      role="img"
-                    >
-                      <use
-                        height="100%"
-                        xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </div>
+                  <use
+                    height="100%"
+                    xlinkHref="/static/img/svg/loading-icons.svg#311_icons_general_lighting_request"
+                  />
+                </svg>
+              </span>
             </div>
           </div>
         </div>
@@ -153,203 +143,193 @@ exports[`choose page rendering 1`] = `
 `;
 
 exports[`home page rendering 1`] = `
-<div>
-  <div
-    className={
-      Object {
-        "data-css-1rld2am": "",
-      }
+<div
+  className={
+    Object {
+      "data-css-1d2khtc": "",
     }
+  }
+>
+  <div
+    className=" br br-t400 br--y css-182uick"
+    style={Object {}}
   >
-    <div
-      className={
-        Object {
-          "data-css-1d2khtc": "",
-        }
-      }
-    >
+    <div>
       <div
-        className=" br br-t400 br--y css-182uick"
-        style={Object {}}
+        className="p-a300 p-a800--xl"
       >
-        <div>
-          <div
-            className="p-a300 p-a800--xl"
+        <div
+          className="sh sh--y"
+        >
+          <h1
+            className="sh-title"
           >
-            <div
-              className="sh sh--y"
-            >
-              <h1
-                className="sh-title"
+            BOS:311 — File a Report
+          </h1>
+        </div>
+        <div
+          className="t--info m-v300"
+        >
+          Through BOS:311, you can report non-emergency issues with the City.
+        </div>
+        <div
+          className="g m-t500"
+        >
+          <div
+            className="g--7 css-1vm2aiv"
+          >
+            <div>
+              <h2
+                className="stp m-v100"
               >
-                BOS:311 — File a Report
-              </h1>
-            </div>
-            <div
-              className="t--info m-v300"
-            >
-              Through BOS:311, you can report non-emergency issues with the City.
-            </div>
-            <div
-              className="g m-t500"
-            >
-              <div
-                className="g--7 css-1vm2aiv"
-              >
-                <div>
-                  <h2
-                    className="stp m-v100"
-                  >
-                    Tell us your problem:
-                  </h2>
-                  <textarea
-                    aria-label="Description of the problem"
-                    className={
-                      Object {
-                        "data-css-14mt46e": "",
-                      }
-                    }
-                    defaultValue=""
-                    name="description"
-                    onBlur={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    placeholder=""
-                  />
-                </div>
-                <div
-                  className="m-t500"
-                  style={
-                    Object {
-                      "textAlign": "right",
-                    }
+                Tell us your problem:
+              </h2>
+              <textarea
+                aria-label="Description of the problem"
+                className={
+                  Object {
+                    "data-css-14mt46e": "",
                   }
-                >
-                  <button
-                    className="btn css-1q8b8td"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    Start a Report
-                  </button>
-                </div>
-              </div>
-              <div
-                className="g--1 m-v300 css-1sliefw"
+                }
+                defaultValue=""
+                name="description"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                placeholder=""
+              />
+            </div>
+            <div
+              className="m-t500"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="btn css-1q8b8td"
+                disabled={true}
+                onClick={[Function]}
               >
-                <div
-                  className="br br-a150 css-7mg7kt"
-                />
-                <div
-                  className="br br-a150 t--info css-u5arvv"
-                >
-                  or
-                </div>
-                <div
-                  className="br br-a150 css-7mg7kt"
-                />
-              </div>
-              <div
-                className="g--4"
-              >
-                <h2
-                  className="a11y--h"
-                >
-                  Popular Services
-                </h2>
-                <div
-                  className="t--info"
-                >
-                  You can also start a report by picking one of these popular services:
-                </div>
-                <ul
-                  className="ul m-v300"
-                >
-                  <li
-                    className="t--info"
-                  >
-                    <a
-                      className="m-v100"
-                      href="/report/CSMCINC"
-                      onClick={[Function]}
-                    >
-                      Cosmic Incursion
-                    </a>
-                  </li>
-                </ul>
-                <div
-                  className="t--info"
-                >
-                  <a
-                    href="/services"
-                    onClick={[Function]}
-                  >
-                    See all services…
-                  </a>
-                </div>
-              </div>
+                Start a Report
+              </button>
             </div>
           </div>
           <div
-            className="b b--g p-a300 p-a800--xl css-17cwx2g"
-            role="search"
-            style={
-              Object {
-                "paddingBottom": 0,
-                "paddingTop": 0,
-              }
-            }
+            className="g--1 m-v300 css-1sliefw"
+          >
+            <div
+              className="br br-a150 css-7mg7kt"
+            />
+            <div
+              className="br br-a150 t--info css-u5arvv"
+            >
+              or
+            </div>
+            <div
+              className="br br-a150 css-7mg7kt"
+            />
+          </div>
+          <div
+            className="g--4"
           >
             <h2
               className="a11y--h"
             >
-              Public Reports
+              Popular Services
             </h2>
             <div
-              className="g"
+              className="t--info"
             >
-              <form
-                acceptCharset="UTF-8"
-                action="/lookup"
-                className="sf sf--y sf--md g--7 m-v400"
-                method="get"
-                onSubmit={[Function]}
-              >
-                <div
-                  className="sf-i"
-                >
-                  <input
-                    aria-label="Search field"
-                    className="sf-i-f"
-                    name="q"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder="Search by case ID or keywords…"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    className="sf-i-b"
-                    type="submit"
-                  >
-                    Search
-                  </button>
-                </div>
-              </form>
-              <div
-                className="g--1"
-              />
-              <div
-                className="g--4 t--info css-12alag6"
+              You can also start a report by picking one of these popular services:
+            </div>
+            <ul
+              className="ul m-v300"
+            >
+              <li
+                className="t--info"
               >
                 <a
-                  href="/search"
+                  className="m-v100"
+                  href="/report/CSMCINC"
                   onClick={[Function]}
                 >
-                  Browse public cases
+                  Cosmic Incursion
                 </a>
-              </div>
+              </li>
+            </ul>
+            <div
+              className="t--info"
+            >
+              <a
+                href="/services"
+                onClick={[Function]}
+              >
+                See all services…
+              </a>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="b b--g p-a300 p-a800--xl css-17cwx2g"
+        role="search"
+        style={
+          Object {
+            "paddingBottom": 0,
+            "paddingTop": 0,
+          }
+        }
+      >
+        <h2
+          className="a11y--h"
+        >
+          Public Reports
+        </h2>
+        <div
+          className="g"
+        >
+          <form
+            acceptCharset="UTF-8"
+            action="/lookup"
+            className="sf sf--y sf--md g--7 m-v400"
+            method="get"
+            onSubmit={[Function]}
+          >
+            <div
+              className="sf-i"
+            >
+              <input
+                aria-label="Search field"
+                className="sf-i-f"
+                name="q"
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder="Search by case ID or keywords…"
+                type="text"
+                value=""
+              />
+              <button
+                className="sf-i-b"
+                type="submit"
+              >
+                Search
+              </button>
+            </div>
+          </form>
+          <div
+            className="g--1"
+          />
+          <div
+            className="g--4 t--info css-12alag6"
+          >
+            <a
+              href="/search"
+              onClick={[Function]}
+            >
+              Browse public cases
+            </a>
           </div>
         </div>
       </div>

--- a/components/report/request/RequestDialog.js
+++ b/components/report/request/RequestDialog.js
@@ -54,7 +54,9 @@ const COMMON_DIALOG_STYLE = {
 const CORNER_DIALOG_STYLE = css(COMMON_DIALOG_STYLE, {
   margin: 0,
   [MEDIA_LARGE]: {
-    margin: '-0px 70% 0 40px',
+    // comedy bottom margin to push this up into the corner, otherwise it would
+    // get vertically centered.
+    margin: '-0px 70% 90vh 40px',
     minWidth: 450,
   },
 });

--- a/components/report/request/__snapshots__/RequestDialog.test.js.snap
+++ b/components/report/request/__snapshots__/RequestDialog.test.js.snap
@@ -169,6 +169,7 @@ exports[`methods submitRequest success 2`] = `
           "browserLocation": BrowserLocation {
             "watchId": null,
           },
+          "languages": Array [],
           "mapLocation": MapLocation {},
           "requestSearch": RequestSearch {
             "searchDisposer": null,
@@ -401,7 +402,7 @@ exports[`rendering location 1`] = `
 <div
   className={
     Object {
-      "data-css-1xznh3v": "",
+      "data-css-5ju6dk": "",
     }
   }
 >

--- a/components/report/translate/TranslateDialog.stories.js
+++ b/components/report/translate/TranslateDialog.stories.js
@@ -6,5 +6,10 @@ import TranslateDialog from './TranslateDialog';
 
 storiesOf('TranslateDialog', module)
   .add('loading', () => (
-    <TranslateDialog />
+    <TranslateDialog
+      languages={[
+        { code: 'en', region: 'US', quality: 1 },
+        { code: 'en', region: undefined, quality: 0.8 },
+      ]}
+    />
   ));

--- a/components/report/translate/TranslateDialog.test.js
+++ b/components/report/translate/TranslateDialog.test.js
@@ -1,0 +1,34 @@
+// @flow
+
+import TranslateDialog from './TranslateDialog';
+
+describe('findLanguage', () => {
+  it('defaults to null', () => {
+    const code = TranslateDialog.findLanguage(
+      [{ code: 'fr', region: 'CA', quality: 1.0 }],
+    );
+
+    expect(code).toEqual(null);
+  });
+
+  it('detects Vietnamese', () => {
+    const code = TranslateDialog.findLanguage(
+      [{ code: 'vi', region: null, quality: 1.0 }],
+    );
+
+    expect(code).toEqual('vi');
+  });
+
+  it('detects a Chinese region', () => {
+    const code = TranslateDialog.findLanguage(
+      [
+        { code: 'zh', region: 'TW', quality: 1 },
+        { code: 'zh', region: null, quality: 0.8 },
+        { code: 'en', region: 'US', quality: 0.6 },
+        { code: 'en', region: null, quality: 0.4 },
+      ],
+    );
+
+    expect(code).toEqual('zh-TW');
+  });
+});

--- a/components/reports/CaseView.js
+++ b/components/reports/CaseView.js
@@ -22,7 +22,7 @@ export type Props = {|
 
 const CONTAINER_STYLE = css({
   maxWidth: 960,
-  margin: '40px auto',
+  margin: '0 auto',
 });
 
 const HEADER_STYLE = css({
@@ -98,7 +98,7 @@ export default function CaseView({ request, store, submitted }: Props) {
   const waypointIcon = request.status === 'open' ? waypoints.greenFilled : waypoints.orangeFilled;
 
   return (
-    <div className={CONTAINER_STYLE}>
+    <div className={`p-a300 ${CONTAINER_STYLE.toString()}`}>
       <div className={`p-a500 ${HEADER_STYLE.toString()}`}>
         <SectionHeader subtitle={`Case no: #${request.id}`}>{request.service.name}</SectionHeader>
 

--- a/components/reports/__snapshots__/ReportsLayout.test.js.snap
+++ b/components/reports/__snapshots__/ReportsLayout.test.js.snap
@@ -152,11 +152,7 @@ exports[`case rendering 1`] = `
     role="main"
   >
     <div
-      className={
-        Object {
-          "data-css-38wlrs": "",
-        }
-      }
+      className="p-a300 css-jy1f9a"
     >
       <div
         className="p-a500 css-pym862"

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -16,6 +16,12 @@ import RouterListener from './RouterListener';
 // MobX will enforce that state changes only happen in action blocks.
 useStrict(true);
 
+export type LanguagePreference = {|
+  code: string,
+  region: ?string,
+  quality: number,
+|};
+
 export class AppStore {
   // Initialization data from the server
   apiKeys: {[service: string]: any} = {};
@@ -26,6 +32,8 @@ export class AppStore {
   browserLocation: BrowserLocation = new BrowserLocation();
   mapLocation: MapLocation = new MapLocation();
   allServices: AllServices = new AllServices();
+
+  languages: LanguagePreference[] = [];
 
   @observable liveAgentAvailable: boolean = (typeof window !== 'undefined' && window.LIVE_AGENT_AVAILABLE) || false;
 

--- a/lib/mixins/with-store.js
+++ b/lib/mixins/with-store.js
@@ -28,6 +28,7 @@ export default <OP, P: $Subtype<Object>, S> (Component: Class<React.Component<OP
 
     const initialStoreState = req ? {
       apiKeys: req.apiKeys,
+      languages: req.languages,
       liveAgentButtonId: req.liveAgentButtonId,
     } : null;
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "graphql-server-hapi": "^0.7.2",
     "graphql-tools": "^0.10.0",
     "hapi": "^16.1.1",
+    "hapi-accept-language": "^1.0.1",
     "https-proxy-agent": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",
     "leaflet": "1.0.2",

--- a/server/next-handlers.js
+++ b/server/next-handlers.js
@@ -13,19 +13,27 @@ type HapiInject = (options: {|
   payload: any,
 |}) => Promise<HapiResponse>;
 
+type Language = {|
+  code: string,
+  region: ?string,
+  quality: number,
+|};
+
 export type RequestAdditions = {|
   hapiInject: HapiInject,
+  languages: Language[],
   apiKeys: {|
     cloudinary: Object,
     mapbox: Object,
   |},
   liveAgentButtonId: string,
   loopbackGraphqlCache: {[key: string]: mixed},
-|}
+|};
 
-const nextHandler = (app, page, staticQuery) => async ({ method, server, raw: { req, res }, query, params }, reply) => {
+const nextHandler = (app, page, staticQuery) => async ({ method, server, raw: { req, res }, query, params, pre }, reply) => {
   const requestAdditions: RequestAdditions = {
     hapiInject: server.inject.bind(server),
+    languages: pre.language,
     apiKeys: {
       cloudinary: {
         url: `https://api.cloudinary.com/v1_1/${process.env.CLOUDINARY_CLOUD || ''}`,

--- a/server/server.js
+++ b/server/server.js
@@ -5,6 +5,7 @@ import Good from 'good';
 import next from 'next';
 import fs from 'fs';
 import { graphqlHapi, graphiqlHapi } from 'graphql-server-hapi';
+import acceptLanguagePlugin from 'hapi-accept-language';
 
 import { nextHandler, nextDefaultHandler } from './next-handlers';
 import Open311 from './services/Open311';
@@ -59,6 +60,8 @@ export default async function startServer({ opbeat }: any) {
       },
     },
   });
+
+  server.register(acceptLanguagePlugin);
 
   server.register({
     register: graphqlHapi,

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,6 +125,10 @@ abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
+accept-language-parser@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.4.0.tgz#45f242245ddb142e454f109ed6ac076e40b89de0"
+
 accept@2.x.x:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/accept/-/accept-2.1.3.tgz#ab0f5bda4c449bbe926aea607b3522562f5acf86"
@@ -3489,6 +3493,12 @@ handlebars@^4.0.3:
     source-map "^0.4.4"
   optionalDependencies:
     uglify-js "^2.6"
+
+hapi-accept-language@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hapi-accept-language/-/hapi-accept-language-1.0.1.tgz#faf30bf4ee0fbf8f7712672f025b89c6d48dcd01"
+  dependencies:
+    accept-language-parser "^1.0.2"
 
 hapi@^16.1.1:
   version "16.1.1"


### PR DESCRIPTION
If the browser language is not EN and we have a translation helper for
it, we show the dialog instead of the home page.

Adds a "continue" link.

Also fixes up some dialog-centering behavior.