### PR TITLE
Advances panes on form submit

### DIFF
--- a/components/report/__snapshots__/ReportLayout.test.js.snap
+++ b/components/report/__snapshots__/ReportLayout.test.js.snap
@@ -403,7 +403,7 @@ exports[`existing service page rendering 1`] = `
             <button
               className="btn g--3"
               disabled={true}
-              onClick={[Function]}
+              type="submit"
             >
               Next
             </button>
@@ -818,7 +818,7 @@ exports[`existing service page rendering phone 1`] = `
             <button
               className="btn g--3"
               disabled={true}
-              onClick={[Function]}
+              type="submit"
             >
               Next
             </button>

--- a/components/report/request/ContactPane.js
+++ b/components/report/request/ContactPane.js
@@ -52,8 +52,11 @@ export default class ContactPane extends React.Component {
   }
 
   @action.bound
-  continueWithContactInfo() {
+  continueWithContactInfo(ev: SyntheticInputEvent) {
     const { requestForm, nextFunc } = this.props;
+
+    ev.preventDefault();
+
     requestForm.sendContactInfo = true;
     nextFunc();
   }
@@ -101,13 +104,13 @@ export default class ContactPane extends React.Component {
     const { rememberInfo } = this.localStorageContactInfo;
 
     return (
-      <form onSubmit={this.cancelSubmit}>
+      <form onSubmit={this.continueWithContactInfo}>
         <div>
           <SectionHeader>{ serviceName }</SectionHeader>
           <p className="m-v300 t--info">
-          We’ll use your contact info to send you email about the status of your
-          report and to follow up with you if necessary.
-        </p>
+            We’ll use your contact info to send you email about the status of your
+            report and to follow up with you if necessary.
+          </p>
 
           <p className="m-v300 t--subinfo">
             <strong>Your contact info will not be made public.</strong>{' '}
@@ -152,7 +155,8 @@ export default class ContactPane extends React.Component {
           <div className={`g--8 t--info m-v200 ${RIGHT_ON_LARGE_STYLE.toString()}`}>
             {!contactInfoRequirementsMet && <span>Please fill out <span className="t--req">required</span> fields to continue</span>}
           </div>
-          <button className="btn g--4" onClick={this.continueWithContactInfo} disabled={!contactInfoRequirementsMet}>Submit Report</button>
+
+          <button className="btn g--4" type="submit" disabled={!contactInfoRequirementsMet}>Submit Report</button>
         </div>
       </form>
     );

--- a/components/report/request/QuestionsPane.js
+++ b/components/report/request/QuestionsPane.js
@@ -79,7 +79,7 @@ export default class QuestionsPane extends React.Component {
   }
 
   @action
-  componnetWillUnmount() {
+  componentWillUnmount() {
     this.imageUploader.adoptedUrlObservable = null;
   }
 
@@ -108,16 +108,21 @@ export default class QuestionsPane extends React.Component {
     requestForm.description = ev.target.value;
   }
 
+  @action.bound
+  handleSubmit(ev: SyntheticInputEvent) {
+    const { nextFunc } = this.props;
+
+    ev.preventDefault();
+
+    nextFunc();
+  }
+
   setDropEl = (dropEl: ?Dropzone) => {
     this.dropEl = dropEl;
   }
 
-  cancelSubmit = (ev: SyntheticInputEvent) => {
-    ev.preventDefault();
-  };
-
   render() {
-    const { requestForm, serviceName, nextFunc, nextIsSubmit } = this.props;
+    const { requestForm, serviceName, nextIsSubmit } = this.props;
     const { description, questions, questionRequirementsMet } = requestForm;
 
     const questionsEls = [];
@@ -134,7 +139,7 @@ export default class QuestionsPane extends React.Component {
     });
 
     return (
-      <form onSubmit={this.cancelSubmit}>
+      <form onSubmit={this.handleSubmit}>
         <SectionHeader>{ serviceName }</SectionHeader>
 
         <div className="g g--top">
@@ -154,7 +159,7 @@ export default class QuestionsPane extends React.Component {
           <div className={`g--9 t--info m-v200 ${RIGHT_ON_LARGE_STYLE.toString()}`}>
             {!questionRequirementsMet && <span>Please fill out <span className="t--req">required</span> fields to continue</span>}
           </div>
-          <button className="btn g--3" onClick={nextFunc} disabled={!questionRequirementsMet}>{nextIsSubmit ? 'Submit Request' : 'Next'}</button>
+          <button className="btn g--3" type="submit" disabled={!questionRequirementsMet}>{nextIsSubmit ? 'Submit Request' : 'Next'}</button>
         </div>
       </form>
     );

--- a/components/report/request/SubmitPane.js
+++ b/components/report/request/SubmitPane.js
@@ -24,6 +24,9 @@ export default function SubmitPane(props: Props) {
       return (
         <div>
           <SectionHeader>Submitting…</SectionHeader>
+
+          <div className="t--intro m-v500">Please wait while we save your request.</div>
+
           <div className={`m-v500 p-a500 ${LOADING_CONTAINER_STYLE.toString()}`}>
             <LoadingBuildings />
           </div>

--- a/components/report/request/__snapshots__/ContactPane.test.js.snap
+++ b/components/report/request/__snapshots__/ContactPane.test.js.snap
@@ -199,7 +199,7 @@ exports[`blank request 1`] = `
     <button
       className="btn g--4"
       disabled={true}
-      onClick={[Function]}
+      type="submit"
     >
       Submit Report
     </button>
@@ -396,7 +396,7 @@ exports[`filled request 1`] = `
     <button
       className="btn g--4"
       disabled={false}
-      onClick={[Function]}
+      type="submit"
     >
       Submit Report
     </button>

--- a/components/report/request/__snapshots__/QuestionsPane.test.js.snap
+++ b/components/report/request/__snapshots__/QuestionsPane.test.js.snap
@@ -119,7 +119,7 @@ exports[`blank request 1`] = `
     <button
       className="btn g--3"
       disabled={false}
-      onClick={[Function]}
+      type="submit"
     >
       Next
     </button>
@@ -246,7 +246,7 @@ exports[`existing description 1`] = `
     <button
       className="btn g--3"
       disabled={false}
-      onClick={[Function]}
+      type="submit"
     >
       Next
     </button>
@@ -395,7 +395,7 @@ exports[`service with metadata 1`] = `
     <button
       className="btn g--3"
       disabled={false}
-      onClick={[Function]}
+      type="submit"
     >
       Next
     </button>

--- a/components/report/request/__snapshots__/RequestDialog.test.js.snap
+++ b/components/report/request/__snapshots__/RequestDialog.test.js.snap
@@ -390,7 +390,7 @@ exports[`rendering contact 1`] = `
         <button
           className="btn g--4"
           disabled={true}
-          onClick={[Function]}
+          type="submit"
         >
           Submit Report
         </button>
@@ -773,7 +773,7 @@ exports[`rendering questions 1`] = `
         <button
           className="btn g--3"
           disabled={true}
-          onClick={[Function]}
+          type="submit"
         >
           Next
         </button>


### PR DESCRIPTION
The existing buttons would cause a page change but also trigger a form
submit, which wouldn't get cancelled because it would happen after the
component had been unmounted. This caused warnings in Chrome and the
page to reload on iOS.

Also adds text to submit dialog.