### PR TITLE
Adds more specific Open311 error message

### DIFF
--- a/server/services/Open311.js
+++ b/server/services/Open311.js
@@ -146,7 +146,7 @@ export default class Open311 {
 
   constructor(endpoint: ?string, apiKey: ?string, opbeat: any) {
     if (!endpoint) {
-      throw new Error('Must specify an endpoint');
+      throw new Error('Must specify an Open311 endpoint');
     }
 
     this.endpoint = endpoint;


### PR DESCRIPTION
Keeps it from looking like an internal GraphQL error.