### PR TITLE
Fixes up detecting when it's ok to auto-move map

### DIFF
--- a/components/request/request/__snapshots__/RequestDialog.test.js.snap
+++ b/components/request/request/__snapshots__/RequestDialog.test.js.snap
@@ -158,6 +158,9 @@ exports[`methods submitRequest success 2`] = `
           "languages": Array [],
           "mapLocation": MapLocation {},
           "requestSearch": RequestSearch {
+            "boundsSet": false,
+            "boundsSetDisposer": null,
+            "mapMoved": false,
             "searchDisposer": null,
           },
           "ui": Ui {

--- a/components/search/SearchLayout.js
+++ b/components/search/SearchLayout.js
@@ -178,7 +178,7 @@ export default class SearchLayout extends React.Component {
           return;
         }
 
-        if (!mapCenter) {
+        if (!mapCenter || !store.requestSearch.mapMoved) {
           this.locationMap.visitLocation(browserLocation, true);
         }
       },


### PR DESCRIPTION
Changes to the bounds broke our hack of detecting the mobile center
point as the way to tell if the map should move.