### PR TITLE
Remove flex on search results

### DIFF
--- a/components/search/RecentRequests.js
+++ b/components/search/RecentRequests.js
@@ -20,9 +20,6 @@ if (typeof window !== 'undefined') {
 const CONTAINER_STYLE = css({
   background: 'white',
   position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  flex: 1,
 
   [MEDIA_LARGE]: {
     width: '40%',
@@ -41,15 +38,15 @@ const SEARCH_CONTAINER_STYLE = css({
   },
 });
 
+// While we would prefer to make this so that the loading spinner is vertically
+// centered in the height of the empty search results area, that runs afoul of
+// IE 10/11 flexbox behavior. To get the height of the empty area down to this
+// element we need to flex: 1 on the column, but those browsers won't let a
+// flex: 1 element grow its parent, so the column could never expand larger to
+// accommodate search results.
 const LOADING_CONTAINER_STYLE = css({
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-around',
+  marginTop: '10%',
   [MEDIA_LARGE]: {
-    // for IE, since the parent we're flexing to is only defined with
-    // min-height, IE won't grow to it.
-    flex: 'none',
     marginTop: '30%',
   },
 });

--- a/components/search/SearchLayout.js
+++ b/components/search/SearchLayout.js
@@ -89,12 +89,6 @@ const MAP_CONTAINER_STYLE = css({
   },
 });
 
-const RECENT_REQUESTS_CONTAINER_STYLE = css({
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-});
-
 const FULL_MAP_CONTAINER_STYLE = css(MAP_CONTAINER_STYLE, {
   height: 'auto',
   flex: 1,
@@ -342,7 +336,7 @@ export default class SearchLayout extends React.Component {
             />
           </div>
 
-          {!mapView && <div className={RECENT_REQUESTS_CONTAINER_STYLE} ref={this.setContainer}><RecentRequests store={store} /></div> }
+          {!mapView && <div ref={this.setContainer}><RecentRequests store={store} /></div> }
 
           { mapView && (
             <div className="g p-a300"><button type="button" className="btn g--12" onClick={this.switchToListView}>List View</button></div>

--- a/components/search/__snapshots__/RecentRequests.test.js.snap
+++ b/components/search/__snapshots__/RecentRequests.test.js.snap
@@ -4,7 +4,7 @@ exports[`rendering results loaded 1`] = `
 <div
   className={
     Object {
-      "data-css-1g83m8j": "",
+      "data-css-hrpe2f": "",
     }
   }
 >
@@ -137,7 +137,7 @@ exports[`rendering with request selected 1`] = `
 <div
   className={
     Object {
-      "data-css-1g83m8j": "",
+      "data-css-hrpe2f": "",
     }
   }
 >

--- a/components/search/__snapshots__/SearchLayout.test.js.snap
+++ b/components/search/__snapshots__/SearchLayout.test.js.snap
@@ -119,17 +119,11 @@ exports[`search form rendering 1`] = `
         }
       }
     />
-    <div
-      className={
-        Object {
-          "data-css-mxwefu": "",
-        }
-      }
-    >
+    <div>
       <div
         className={
           Object {
-            "data-css-1g83m8j": "",
+            "data-css-hrpe2f": "",
           }
         }
       >
@@ -173,7 +167,7 @@ exports[`search form rendering 1`] = `
         <div
           className={
             Object {
-              "data-css-1124mnf": "",
+              "data-css-1ctqqrj": "",
             }
           }
         >


### PR DESCRIPTION
Putting flex back in for vertical centering of the loading spinner regressed the issue where search results weren't pushing the footer down to the bottom of the screen. Gives up on vertical centering and just puts a bit of top margin instead.