### PR TITLE
Disables sending address_id

### DIFF
--- a/server/graphql/mutation.js
+++ b/server/graphql/mutation.js
@@ -65,9 +65,12 @@ export const resolvers = {
         createArgs.address_string = args.address;
       }
 
-      if (args.addressId) {
-        createArgs.address_id = args.addressId;
-      }
+      // TODO(finh): Re-enable when
+      // https://github.com/CityOfBoston/311/issues/599 is fixed
+      //
+      // if (args.addressId) {
+      //   createArgs.address_id = args.addressId;
+      // }
 
       if (args.location) {
         createArgs.lat = args.location.lat;


### PR DESCRIPTION
Adding in address_id prevents all storage of location information on
Salesforce, so we'll remove it for now.