### PR TITLE
Defaults a blank "updated at" date

### DIFF
--- a/server/graphql/request.js
+++ b/server/graphql/request.js
@@ -67,7 +67,8 @@ export const resolvers = {
     location: (r: Root) =>
       r.lat != null && r.long != null ? { lat: r.lat, lng: r.long } : null,
     requestedAt: (r: Root) => moment(r.requested_datetime).unix(),
-    updatedAt: (r: Root) => moment(r.updated_datetime).unix(),
+    updatedAt: (r: Root) =>
+      moment(r.updated_datetime || r.requested_datetime).unix(),
     // We format timezones on the server to avoid having to ship moment to the client
     requestedAtString: (r: Root, { format = '' }: DateStringArguments) =>
       moment(r.requested_datetime).tz('America/New_York').format(format),


### PR DESCRIPTION
Uses the requested date if updated at is missing, so we always have
something there.