### PR TITLE
Reverts "import * from React"

### DIFF
--- a/components/case/CaseLayout.js
+++ b/components/case/CaseLayout.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import type { Context } from 'next';
 import Head from 'next/head';
 

--- a/components/case/CaseLayout.stories.js
+++ b/components/case/CaseLayout.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import page from '../../storybook/page';

--- a/components/case/CaseView.js
+++ b/components/case/CaseView.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/no-danger: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 
 import type { Request } from '../../data/types';

--- a/components/case/CaseView.stories.js
+++ b/components/case/CaseView.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import inPercy from '@percy-io/in-percy';
 

--- a/components/common/DescriptionBox.js
+++ b/components/common/DescriptionBox.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 
 export type DefaultProps = {|

--- a/components/common/DescriptionBox.stories.js
+++ b/components/common/DescriptionBox.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import DescriptionBox from './DescriptionBox';

--- a/components/common/FormDialog.js
+++ b/components/common/FormDialog.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 
 import { MEDIA_LARGE, HEADER_HEIGHT, CLEAR_FIX } from '../style-constants';

--- a/components/common/FormDialog.stories.js
+++ b/components/common/FormDialog.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import FormDialog from './FormDialog';
 import SectionHeader from './SectionHeader';

--- a/components/common/LoadingBuildings.js
+++ b/components/common/LoadingBuildings.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/no-danger: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import { now } from 'mobx-utils';

--- a/components/common/LoadingBuildings.stories.js
+++ b/components/common/LoadingBuildings.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoadingBuildings from './LoadingBuildings';
 

--- a/components/common/LoadingIcons.js
+++ b/components/common/LoadingIcons.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/no-danger: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import { now } from 'mobx-utils';

--- a/components/common/LoadingIcons.stories.js
+++ b/components/common/LoadingIcons.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoadingIcons from './LoadingIcons';
 

--- a/components/common/Nav.js
+++ b/components/common/Nav.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 
 import Link from 'next/link';
 

--- a/components/common/Nav.stories.js
+++ b/components/common/Nav.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Nav from './Nav';
 

--- a/components/common/SectionHeader.js
+++ b/components/common/SectionHeader.js
@@ -1,10 +1,13 @@
 // @flow
 
-import * as React from 'react';
+import React, {
+  type Element as ReactElement,
+  type Node as ReactNode,
+} from 'react';
 
 type Props = {|
-  subtitle?: string | React.Element<*>,
-  children: React.Node,
+  subtitle?: string | ReactElement<*>,
+  children: ReactNode,
 |};
 
 export default function SectionHeader({ subtitle, children }: Props) {

--- a/components/faq/FaqLayout.js
+++ b/components/faq/FaqLayout.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/prefer-stateless-function: 0 */
 
-import * as React from 'react';
+import React, { type Node as ReactNode } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { css } from 'glamor';
@@ -26,7 +26,7 @@ const ICON_STYLE = css({
 
 type QuestionProps = {|
   title: string,
-  children: React.Node,
+  children: ReactNode,
 |};
 
 function Question({ title, children }: QuestionProps) {

--- a/components/faq/FaqLayout.stories.js
+++ b/components/faq/FaqLayout.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import page from '../../storybook/page';

--- a/components/map/LocationMap.js
+++ b/components/map/LocationMap.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/no-unused-prop-types: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { css } from 'glamor';
 import { computed, action, reaction, autorun } from 'mobx';

--- a/components/map/LocationMap.stories.js
+++ b/components/map/LocationMap.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import inPercy from '@percy-io/in-percy';
 import LocationMap from './LocationMap';

--- a/components/map/LocationMap.test.js
+++ b/components/map/LocationMap.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { runInAction } from 'mobx';

--- a/components/map/RequestPopup.js
+++ b/components/map/RequestPopup.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { css } from 'glamor';
 import { GRAY_300, GREEN, YELLOW } from '../style-constants';

--- a/components/map/RequestPopup.stories.js
+++ b/components/map/RequestPopup.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { YELLOW } from '../style-constants';

--- a/components/map/SearchMarkerPool.js
+++ b/components/map/SearchMarkerPool.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { action, computed, autorun } from 'mobx';
 import type { IComputedValue } from 'mobx';

--- a/components/request/RequestLayout.js
+++ b/components/request/RequestLayout.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import Router from 'next/router';
 import type { Context } from 'next';

--- a/components/request/RequestLayout.stories.js
+++ b/components/request/RequestLayout.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from 'mobx';
 

--- a/components/request/RequestLayout.test.js
+++ b/components/request/RequestLayout.test.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint no-fallthrough: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import Router from 'next/router';
 

--- a/components/request/home/ChooseServicePane.js
+++ b/components/request/home/ChooseServicePane.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { css } from 'glamor';

--- a/components/request/home/ChooseServicePane.stories.js
+++ b/components/request/home/ChooseServicePane.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import ChooseServicePane from './ChooseServicePane';
 import FormDialog from '../../common/FormDialog';

--- a/components/request/home/HomeDialog.js
+++ b/components/request/home/HomeDialog.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { action, observable, reaction, runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import debounce from 'lodash/debounce';

--- a/components/request/home/HomeDialog.test.js
+++ b/components/request/home/HomeDialog.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 

--- a/components/request/home/HomePane.js
+++ b/components/request/home/HomePane.js
@@ -2,7 +2,7 @@
 /* global liveagent */
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import { action, computed, observable } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/request/home/HomePane.stories.js
+++ b/components/request/home/HomePane.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { AppStore } from '../../../data/store';

--- a/components/request/request/AttributeDateField.js
+++ b/components/request/request/AttributeDateField.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import { action, observable, reaction, computed } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/request/request/AttributeField.js
+++ b/components/request/request/AttributeField.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
 import { css } from 'glamor';

--- a/components/request/request/AttributeField.stories.js
+++ b/components/request/request/AttributeField.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import FormDialog from '../../common/FormDialog';
 import Question from '../../../data/store/Question';

--- a/components/request/request/AttributeField.test.js
+++ b/components/request/request/AttributeField.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { mount } from 'enzyme';
 
 import Question from '../../../data/store/Question';

--- a/components/request/request/ContactPane.js
+++ b/components/request/request/ContactPane.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/request/request/ContactPane.stories.js
+++ b/components/request/request/ContactPane.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 

--- a/components/request/request/LocationPopUp.js
+++ b/components/request/request/LocationPopUp.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import { action, reaction } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/request/request/LocationPopUp.stories.js
+++ b/components/request/request/LocationPopUp.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import LocationPopUp from './LocationPopUp';

--- a/components/request/request/QuestionsPane.js
+++ b/components/request/request/QuestionsPane.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import { action, extras } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/request/request/QuestionsPane.stories.js
+++ b/components/request/request/QuestionsPane.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 

--- a/components/request/request/RequestDialog.js
+++ b/components/request/request/RequestDialog.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import Head from 'next/head';
 import Router from 'next/router';
 import { action, observable, autorun } from 'mobx';

--- a/components/request/request/RequestDialog.test.js
+++ b/components/request/request/RequestDialog.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import { runInAction } from 'mobx';

--- a/components/request/request/SubmitPane.js
+++ b/components/request/request/SubmitPane.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { css } from 'glamor';
 import SectionHeader from '../../common/SectionHeader';
 import LoadingBuildings from '../../common/LoadingBuildings';

--- a/components/request/request/SubmitPane.stories.js
+++ b/components/request/request/SubmitPane.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import SubmitPane from './SubmitPane';

--- a/components/request/translate/TranslateDialog.js
+++ b/components/request/translate/TranslateDialog.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/jsx-no-bind: 0 */
 
-import * as React from 'react';
+import React from 'react';
 
 import { css } from 'glamor';
 import { observable, action } from 'mobx';

--- a/components/request/translate/TranslateDialog.stories.js
+++ b/components/request/translate/TranslateDialog.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import TranslateDialog from './TranslateDialog';
 

--- a/components/search/RecentRequestRow.js
+++ b/components/search/RecentRequestRow.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { action, computed, observable } from 'mobx';
 import { observer } from 'mobx-react';

--- a/components/search/RecentRequests.js
+++ b/components/search/RecentRequests.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { observable, action, autorun, untracked } from 'mobx';
 import { observer } from 'mobx-react';
 import { css } from 'glamor';

--- a/components/search/RecentRequests.stories.js
+++ b/components/search/RecentRequests.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import RecentRequests from './RecentRequests';

--- a/components/search/RecentRequestsSearchForm.js
+++ b/components/search/RecentRequestsSearchForm.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
 

--- a/components/search/SearchLayout.js
+++ b/components/search/SearchLayout.js
@@ -2,7 +2,7 @@
 
 import 'url-search-params-polyfill';
 
-import * as React from 'react';
+import React from 'react';
 import type { Context } from 'next';
 import Router from 'next/router';
 import { css } from 'glamor';

--- a/components/search/SearchLayout.stories.js
+++ b/components/search/SearchLayout.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from 'mobx';
 

--- a/components/services/ServicesLayout.js
+++ b/components/services/ServicesLayout.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint react/prefer-stateless-function: 0 react/no-unused-prop-types: 0 */
 
-import * as React from 'react';
+import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { action } from 'mobx';

--- a/components/services/ServicesLayout.stories.js
+++ b/components/services/ServicesLayout.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from 'mobx';
 

--- a/lib/mixins/with-glamor.js
+++ b/lib/mixins/with-glamor.js
@@ -7,12 +7,12 @@
 // beginning of files, and we need to rehydrate before any Glamor "css"
 // statements are processed.
 
-import * as React from 'react';
+import React, { type ComponentType as ReactComponentType } from 'react';
 import { rehydrate } from 'glamor';
 
 export default <Props: {}>(
-  componentFn: () => React.ComponentType<Props>
-): React.ComponentType<Props> => {
+  componentFn: () => ReactComponentType<Props>
+): ReactComponentType<Props> => {
   if (process.browser) {
     // eslint-disable-next-line no-underscore-dangle
     rehydrate(window.__NEXT_DATA__.ids);

--- a/lib/mixins/with-store.js
+++ b/lib/mixins/with-store.js
@@ -5,7 +5,7 @@ import 'core-js/shim';
 
 import svg4everybody from 'svg4everybody';
 
-import * as React from 'react';
+import React, { type ComponentType as ReactComponentType } from 'react';
 import type { Context } from 'next';
 import { runInAction } from 'mobx';
 
@@ -30,8 +30,8 @@ type PropsExtension = {
 };
 
 export default <Props: {}>(
-  Component: React.ComponentType<Props & PropsExtension>
-): React.ComponentType<Props> =>
+  Component: ReactComponentType<Props & PropsExtension>
+): ReactComponentType<Props> =>
   class WithStore extends React.Component<Props> {
     store: AppStore;
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint react/no-danger: 0 */
-import * as React from 'react';
+import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import { renderStatic } from 'glamor/server';
 import mobxReact from 'mobx-react';

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -3,7 +3,7 @@
 
 // Forked from next.js to add Opbeat error sending
 
-import * as React from 'react';
+import React from 'react';
 import HTTPStatus from 'http-status';
 import Head from 'next/head';
 

--- a/storybook/centered.js
+++ b/storybook/centered.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React, { type Element as ReactElement } from 'react';
 import { css } from 'glamor';
 
 const CENTERED_STYLE = css({
@@ -13,7 +13,7 @@ const CENTERED_STYLE = css({
 });
 
 type Props = {|
-  children: React.Element<any> | Array<React.Element<any>>,
+  children: ReactElement<any> | Array<ReactElement<any>>,
 |};
 
 function Centered({ children }: Props) {
@@ -24,7 +24,7 @@ function Centered({ children }: Props) {
   );
 }
 
-export default function centered(stories: () => React.Element<any>) {
+export default function centered(stories: () => ReactElement<any>) {
   return (
     <Centered>
       {stories()}

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint no-underscore-dangle: 0 */
 
-import * as React from 'react';
+import React, { type Element as ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import Router from 'next/router';
 import { configure, addDecorator } from '@storybook/react';
@@ -33,7 +33,7 @@ try {
 }
 
 class Wrapper extends React.Component<{
-  children: React.Element<any>,
+  children: ReactElement<any>,
 }> {
   static childContextTypes = {
     router: PropTypes.object,
@@ -72,7 +72,7 @@ function loadStories() {
   storiesContext.keys().forEach(filename => storiesContext(filename));
 }
 
-addDecorator((story: () => React.Element<any>) => {
+addDecorator((story: () => ReactElement<any>) => {
   if (window.parent) {
     // eslint-disable-next-line no-underscore-dangle
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ =

--- a/storybook/page.js
+++ b/storybook/page.js
@@ -1,13 +1,13 @@
 // @flow
 /* eslint react/no-danger: 0 */
 
-import * as React from 'react';
+import React, { type Node as ReactNode } from 'react';
 
 import headerHtml from '../templates/header.html';
 import footerHtml from '../templates/footer.html';
 import navigationHtml from '../templates/navigation.html';
 
-function Page({ children }: { children: React.Node }) {
+function Page({ children }: { children: ReactNode }) {
   return (
     <div>
       <input
@@ -43,7 +43,7 @@ function Page({ children }: { children: React.Node }) {
   );
 }
 
-export default function page(stories: () => React.Node) {
+export default function page(stories: () => ReactNode) {
   return (
     <Page>
       {stories()}

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,11 +1,11 @@
 <link href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Montserrat:400,700" type="text/css" rel="stylesheet" data-reactroot="" data-reactid="1" data-react-checksum="-1938605290"/>
-<head data-reactroot="" data-reactid="1" data-react-checksum="1390771762">
+<head data-reactroot="" data-reactid="1" data-react-checksum="2061209424">
           <!--[if !IE]><!-->
-            <link href="https://localhost:3001/css/public.css?k=onnap2" type="text/css" rel="stylesheet" />
+            <link href="https://cob-patterns-staging.herokuapp.com/css/public.css?k=onnap2" type="text/css" rel="stylesheet" />
           <!--<![endif]-->
           <!--[if lt IE 10]>
             <script src="/assets/vendor/ie9-polyfill.js"></script>
-            <link href="https://localhost:3001/css/ie.css?k=onnap2" rel="stylesheet" type="text/css">
+            <link href="https://cob-patterns-staging.herokuapp.com/css/ie.css?k=onnap2" rel="stylesheet" type="text/css">
           <![endif]--></head>
 <link href="https://api.mapbox.com/mapbox.js/v3.0.1/mapbox.css" rel="stylesheet" data-reactroot="" data-reactid="1" data-react-checksum="1884170278"/>
 <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.37.0/mapbox-gl.css" rel="stylesheet" data-reactroot="" data-reactid="1" data-react-checksum="-1449055062"/>


### PR DESCRIPTION
The * namespace import ends up importing the deprecated PropTypes and createClass, which cause warnings in React 15.

This can be changed back to the namespace import once we're on React 16.