### PR TITLE
Use plain lat/lng to avoid MobX error

### DIFF
--- a/components/map/LocationMap.js
+++ b/components/map/LocationMap.js
@@ -1113,7 +1113,10 @@ export default class LocationMap extends React.Component<Props> {
     if (ev.originalEvent) {
       ev.originalEvent.stopPropagation();
     }
-    this.currentLocationClicked(ev.target.getLatLng());
+
+    // We need to make this a plain object rather than a LatLng instance.
+    const { lat, lng } = ev.target.getLatLng();
+    this.currentLocationClicked({ lat, lng });
   }
 
   @action.bound


### PR DESCRIPTION
Fix for: https://opbeat.com/city-of-boston/311-web-client-devint2/errors/52/