### PR TITLE
Geo rendering fixes

### DIFF
--- a/server/services/ArcGIS.js
+++ b/server/services/ArcGIS.js
@@ -222,7 +222,7 @@ export function samFeatureToUnit({
 }: LiveSamFeature): UnitResult {
   return {
     location: { lat: geometry.y, lng: geometry.x },
-    address: `${attributes.FULL_ADDRESS}\n${attributes.MAILING_NEIGHBORHOOD}, MA, ${attributes.ZIP_CODE}`,
+    address: `${attributes.FULL_ADDRESS}\n${attributes.MAILING_NEIGHBORHOOD}, ${attributes.ZIP_CODE}`,
     addressId: attributes.SAM_ADDRESS_ID.toString(),
     streetAddress: attributes.FULL_ADDRESS,
     unit: attributes.UNIT,
@@ -356,13 +356,13 @@ export default class ArcGIS {
         address: formatAddress(
           candidate.attributes.Addr_type === 'StreetAddress'
             ? candidate.address
-            : candidate.attributes.User_fld
+            : candidate.attributes.User_fld || candidate.address
         ),
         addressId: candidate.attributes.Ref_ID
           ? candidate.attributes.Ref_ID.toString()
           : null,
         buildingId: candidate.attributes.Street_ID || null,
-        exact: isExactAddress(candidate),
+        exact: true,
       };
     }
   };

--- a/server/services/__snapshots__/ArcGIS.test.js.snap
+++ b/server/services/__snapshots__/ArcGIS.test.js.snap
@@ -3,7 +3,7 @@
 exports[`samFeatureToUnit matches the snapshot 1`] = `
 Object {
   "address": "280-306 Fake St
-Boston, MA, 02108",
+Boston, 02108",
   "addressId": "343432",
   "buildingId": "136614",
   "location": Object {


### PR DESCRIPTION
 - Falls back to address when User_fld is missing (for the
   Seg_Alternate locator)
 - Treats any result (such as intersection) other than StreetAddress as
   "exact."