### PR TITLE
Removes Boston.gov cache-busting param

### DIFF
--- a/lib/make-css.js
+++ b/lib/make-css.js
@@ -6,9 +6,21 @@ import * as React from 'react';
 import stylesheetHrefs from '../templates/stylesheets.json';
 import { assetUrl } from '../components/style-constants';
 
-export default function makeCss(css: ?string) {
-  const publicCssHref = stylesheetHrefs.find(href => href.match(/public\.css/));
-  const otherCssHrefs = stylesheetHrefs.filter(
+type CssOpts = {
+  cacheParam?: string,
+  additionalCss?: string,
+};
+
+export default function makeCss(opts: CssOpts = {}) {
+  const { cacheParam, additionalCss } = opts;
+
+  const cacheBustedCssHrefs = stylesheetHrefs.map(
+    href => (cacheParam ? `${href}?k=${cacheParam}` : href)
+  );
+  const publicCssHref = cacheBustedCssHrefs.find(href =>
+    href.match(/public\.css/)
+  );
+  const otherCssHrefs = cacheBustedCssHrefs.filter(
     href => !href.match(/public\.css/)
   );
 
@@ -62,11 +74,11 @@ export default function makeCss(css: ?string) {
       #nprogress .bar{background:rgba(252,182,26,.7);position:fixed;z-index:1031;top:0;left:0;width:100%;height:65px;}
     `}</style>,
 
-    css &&
+    additionalCss &&
       <style
         type="text/css"
         key="static"
-        dangerouslySetInnerHTML={{ __html: css }}
+        dangerouslySetInnerHTML={{ __html: additionalCss }}
       />,
   ];
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,6 +15,7 @@ type Props = {
   __NEXT_DATA__: Object,
   ids: string[],
   css: string,
+  cacheParam: string,
 };
 
 export default class extends Document {
@@ -24,9 +25,15 @@ export default class extends Document {
     const page = renderPage();
     const styles = extractCritical(page.html || page.errorHtml);
 
+    // This is set by our standard deployment process.
+    const cacheParam =
+      (process.env.GIT_REVISION && process.env.GIT_REVISION.substring(0, 8)) ||
+      '';
+
     return {
       ...page,
       ...styles,
+      cacheParam,
     };
   }
 
@@ -52,7 +59,7 @@ export default class extends Document {
   }
 
   render() {
-    const { css } = this.props;
+    const { css: additionalCss, cacheParam } = this.props;
 
     return (
       <html lang="en" className="js flexbox">
@@ -97,7 +104,7 @@ export default class extends Document {
             href="/assets/icons/android-icon-192x192.png"
           />
 
-          {makeCss(css)}
+          {makeCss({ cacheParam, additionalCss })}
 
           {process.env.GOOGLE_TRACKING_ID &&
             <script

--- a/scripts/fetch-templates.js
+++ b/scripts/fetch-templates.js
@@ -32,16 +32,27 @@ const TEMPLATE_URL = 'https://boston.gov/api/v1/layouts/app';
   const templateHtml = await res.text();
   const $ = cheerio.load(templateHtml);
 
-  $('a').each((i, el) => {
+  $('a, img').each((i, el) => {
     const $el = $(el);
-    let href = $el.attr('href');
-    if (!href.match(/^(https?|mailto):/)) {
-      if (!href.startsWith('/')) {
-        href = `/${href}`;
+
+    // We need to absolutize all URLs, and also strip the cache-busting attribute.
+    ['href', 'src'].forEach(attr => {
+      let url = $el.attr(attr);
+
+      if (!url) {
+        return;
       }
-      href = `https://www.boston.gov${href}`;
-    }
-    $el.attr('href', href);
+
+      if (!url.match(/^(https?|mailto):/)) {
+        if (!url.startsWith('/')) {
+          url = `/${url}`;
+        }
+        url = `https://www.boston.gov${url}`;
+      }
+
+      url = url.replace(/\?k=.*/, '');
+      $el.attr(attr, url);
+    });
   });
 
   // Hand-restore the Translate link because we're not shipping the JS to
@@ -67,7 +78,8 @@ const TEMPLATE_URL = 'https://boston.gov/api/v1/layouts/app';
 
   const stylesheetHrefs = $('link[rel=stylesheet]')
     .map((i, el) => $(el).attr('href'))
-    .toArray();
+    .toArray()
+    .map(url => url.replace(/\?k=.*/, ''));
   fs.writeFileSync(
     path.join(templatesPath, 'stylesheets.json'),
     JSON.stringify(stylesheetHrefs, null, 2)

--- a/scripts/make-storybook-head.js
+++ b/scripts/make-storybook-head.js
@@ -12,13 +12,13 @@ import fs from 'fs';
 import path from 'path';
 import makeCss from '../lib/make-css';
 
-const css = `
+const additionalCss = `
   body, html {
     background-color: #eee;
   }
 `;
 
-const headElements = makeCss(css)
+const headElements = makeCss({ additionalCss })
   .filter(el => !!el)
   .map(el => ReactDOMServer.renderToString(el));
 fs.writeFileSync(

--- a/storybook/__snapshots__/Storyshots.test.js.snap
+++ b/storybook/__snapshots__/Storyshots.test.js.snap
@@ -795,13 +795,13 @@ exports[`Storyshots CaseLayout 404 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -1107,13 +1107,13 @@ exports[`Storyshots CaseLayout Existing 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -4221,13 +4221,13 @@ exports[`Storyshots ErrorLayout 404 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -4511,13 +4511,13 @@ exports[`Storyshots ErrorLayout 500 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -4801,13 +4801,13 @@ exports[`Storyshots FaqLayout FAQ 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -9660,13 +9660,13 @@ exports[`Storyshots RequestLayout Request Form 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -10175,13 +10175,13 @@ exports[`Storyshots RequestLayout Request Page 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -10753,13 +10753,13 @@ exports[`Storyshots RequestLayout Translate Page 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -11295,13 +11295,13 @@ exports[`Storyshots SearchLayout List View 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -11653,13 +11653,13 @@ exports[`Storyshots SearchLayout Map View 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -11962,13 +11962,13 @@ exports[`Storyshots ServicesLayout Collapsed 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">
@@ -12273,13 +12273,13 @@ exports[`Storyshots ServicesLayout Expanded 1`] = `
       <div class=\\"lo lo--abs\\">
     <div class=\\"lo-l\\">
       <a href=\\"https://www.boston.gov/\\">
-        <img src=\\"https://patterns.boston.gov/images/public/logo.svg?k=p05f5p\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
       </a>
               <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
-  <img src=\\"https://patterns.boston.gov/images/public/seal.svg?k=p05f5p\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
 </a>
     <nav class=\\"nv-h\\">
   <ul class=\\"nv-h-l\\">

--- a/templates/header.html
+++ b/templates/header.html
@@ -10,13 +10,13 @@
       <div class="lo lo--abs">
     <div class="lo-l">
       <a href="https://www.boston.gov/">
-        <img src="https://patterns.boston.gov/images/public/logo.svg?k=p05f5p" alt="Boston.gov" class="lo-i">
+        <img src="https://patterns.boston.gov/images/public/logo.svg" alt="Boston.gov" class="lo-i">
       </a>
               <span class="lo-t"><a href="https://www.boston.gov/mayor">Mayor Martin J. Walsh</a></span>
           </div>
   </div>
     <a id="seal" href="https://www.boston.gov/" title="Home" rel="home" class="s">
-  <img src="https://patterns.boston.gov/images/public/seal.svg?k=p05f5p" alt="City of Boston Seal" class="s-i">
+  <img src="https://patterns.boston.gov/images/public/seal.svg" alt="City of Boston Seal" class="s-i">
 </a>
     <nav class="nv-h">
   <ul class="nv-h-l">

--- a/templates/stylesheets.json
+++ b/templates/stylesheets.json
@@ -1,3 +1,3 @@
 [
-  "https://patterns.boston.gov/css/public.css?k=p05f5p"
+  "https://patterns.boston.gov/css/public.css"
 ]


### PR DESCRIPTION
Adds a custom one based on GIT_REVISION.

Keeps Travis from breaking on every boston.gov deploy.