### PR TITLE
Removes breaking width: 100% from form fields

### DIFF
--- a/components/request/request/ContactPane.js
+++ b/components/request/request/ContactPane.js
@@ -12,10 +12,6 @@ import SectionHeader from '../../common/SectionHeader';
 import { MEDIA_LARGE } from '../../style-constants';
 import type RequestForm from '../../../data/store/RequestForm';
 
-const FIELD_STYLE = {
-  width: '100%',
-};
-
 const BOTTOM_ROW_STYLE = css({
   alignItems: 'center',
 });
@@ -155,7 +151,6 @@ export default class ContactPane extends React.Component<Props> {
               name="firstName"
               value={firstName}
               onChange={this.handleChange}
-              style={FIELD_STYLE}
               aria-required
             />
           </div>
@@ -172,7 +167,6 @@ export default class ContactPane extends React.Component<Props> {
               name="lastName"
               value={lastName}
               onChange={this.handleChange}
-              style={FIELD_STYLE}
               aria-required
             />
           </div>
@@ -189,7 +183,6 @@ export default class ContactPane extends React.Component<Props> {
               name="email"
               value={email}
               onChange={this.handleChange}
-              style={FIELD_STYLE}
               aria-required
             />
           </div>
@@ -207,7 +200,6 @@ export default class ContactPane extends React.Component<Props> {
               name="phone"
               value={phone}
               onChange={this.handleChange}
-              style={FIELD_STYLE}
             />
           </div>
 

--- a/components/request/request/__snapshots__/RequestDialog.test.js.snap
+++ b/components/request/request/__snapshots__/RequestDialog.test.js.snap
@@ -1109,11 +1109,6 @@ exports[`rendering contact 1`] = `
             name="firstName"
             onChange={[Function]}
             placeholder="First Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value=""
           />
@@ -1139,11 +1134,6 @@ exports[`rendering contact 1`] = `
             name="lastName"
             onChange={[Function]}
             placeholder="Last Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value=""
           />
@@ -1169,11 +1159,6 @@ exports[`rendering contact 1`] = `
             name="email"
             onChange={[Function]}
             placeholder="Email"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="email"
             value=""
           />
@@ -1197,11 +1182,6 @@ exports[`rendering contact 1`] = `
             onKeyDown={[Function]}
             onPaste={[Function]}
             placeholder="Phone"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="tel"
             value=""
           />

--- a/storybook/__snapshots__/Storyshots.test.js.snap
+++ b/storybook/__snapshots__/Storyshots.test.js.snap
@@ -3704,11 +3704,6 @@ exports[`Storyshots ContactPane Empty 1`] = `
             name="firstName"
             onChange={[Function]}
             placeholder="First Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value=""
           />
@@ -3734,11 +3729,6 @@ exports[`Storyshots ContactPane Empty 1`] = `
             name="lastName"
             onChange={[Function]}
             placeholder="Last Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value=""
           />
@@ -3764,11 +3754,6 @@ exports[`Storyshots ContactPane Empty 1`] = `
             name="email"
             onChange={[Function]}
             placeholder="Email"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="email"
             value=""
           />
@@ -3792,11 +3777,6 @@ exports[`Storyshots ContactPane Empty 1`] = `
             onKeyDown={[Function]}
             onPaste={[Function]}
             placeholder="Phone"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="tel"
             value=""
           />
@@ -3920,11 +3900,6 @@ exports[`Storyshots ContactPane Filled Out 1`] = `
             name="firstName"
             onChange={[Function]}
             placeholder="First Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value="Carol"
           />
@@ -3950,11 +3925,6 @@ exports[`Storyshots ContactPane Filled Out 1`] = `
             name="lastName"
             onChange={[Function]}
             placeholder="Last Name"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="text"
             value="Danvers"
           />
@@ -3980,11 +3950,6 @@ exports[`Storyshots ContactPane Filled Out 1`] = `
             name="email"
             onChange={[Function]}
             placeholder="Email"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="email"
             value="marvel@alphaflight.gov"
           />
@@ -4008,11 +3973,6 @@ exports[`Storyshots ContactPane Filled Out 1`] = `
             onKeyDown={[Function]}
             onPaste={[Function]}
             placeholder="Phone"
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
             type="tel"
             value="+1 (617) 555-1234"
           />


### PR DESCRIPTION
The fields have a `calc` that correctly accommodates paddings and
borders and such.

Fixes #831